### PR TITLE
Move ownership of brake device bits to BrakeModule

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -33,7 +33,7 @@ pub const ADC_SAMPLE_TIME: AdcSampleTime = AdcSampleTime::Cycles480;
 // single read with large Cycles480 sample time?
 pub const DAC_SAMPLE_AVERAGE_COUNT: u32 = 20;
 
-pub struct Board {
+pub struct FullBoard {
     pub debug_console: DebugConsole,
     pub leds: Leds,
     pub user_button: UserButtonPin,
@@ -54,7 +54,26 @@ pub struct Board {
     steering_pins: SteeringPins,
 }
 
-impl Board {
+pub struct Board {
+    pub debug_console: DebugConsole,
+    pub leds: Leds,
+    pub user_button: UserButtonPin,
+    pub delay: Delay,
+    pub timer_ms: MsTimer,
+    pub can_publish_timer: CanPublishTimer,
+    pub wdg: Iwdg<IWDG>,
+    pub reset_conditions: ResetConditions,
+    control_can: ControlCan,
+    obd_can: ObdCan,
+    adc1: Adc<ADC1>,
+    adc3: Adc<ADC3>,
+    throttle_dac: ThrottleDac,
+    steering_dac: SteeringDac,
+    throttle_pins: ThrottlePins,
+    steering_pins: SteeringPins,
+}
+
+impl FullBoard {
     pub fn new() -> Self {
         // read the RCC reset condition flags before anything else
         let reset_conditions = ResetConditions::read_and_clear();
@@ -262,7 +281,7 @@ impl Board {
             &mut rcc.apb1,
         );
 
-        Board {
+        FullBoard {
             debug_console: DebugConsole::new(serial),
             leds,
             user_button: gpioc
@@ -292,17 +311,54 @@ impl Board {
         }
     }
 
+    pub fn split_brake_components(self) -> (Board, BrakeDac, BrakePins) {
+        let FullBoard {
+            debug_console,
+            leds,
+            user_button,
+            delay,
+            timer_ms,
+            can_publish_timer,
+            wdg,
+            reset_conditions,
+            control_can,
+            obd_can,
+            adc1,
+            adc3,
+            brake_dac,
+            throttle_dac,
+            steering_dac,
+            brake_pins,
+            throttle_pins,
+            steering_pins,
+        } = self;
+        (Board {
+            debug_console,
+            leds,
+            user_button,
+            delay,
+            timer_ms,
+            can_publish_timer,
+            wdg,
+            reset_conditions,
+            control_can,
+            obd_can,
+            adc1,
+            adc3,
+            throttle_dac,
+            steering_dac,
+            throttle_pins,
+            steering_pins,
+        }, brake_dac, brake_pins)
+    }
+}
+
+impl Board {
+
     pub fn user_button(&mut self) -> bool {
         self.user_button.is_high()
     }
 
-    pub fn brake_spoof_enable(&mut self) -> &mut BrakeSpoofEnablePin {
-        &mut self.brake_pins.spoof_enable
-    }
-
-    pub fn brake_light_enable(&mut self) -> &mut BrakeLightEnablePin {
-        &mut self.brake_pins.brake_light_enable
-    }
 
     pub fn throttle_spoof_enable(&mut self) -> &mut ThrottleSpoofEnablePin {
         &mut self.throttle_pins.spoof_enable
@@ -318,10 +374,6 @@ impl Board {
 
     pub fn obd_can(&mut self) -> &mut ObdCan {
         &mut self.obd_can
-    }
-
-    pub fn brake_dac(&mut self) -> &mut BrakeDac {
-        &mut self.brake_dac
     }
 
     pub fn throttle_dac(&mut self) -> &mut ThrottleDac {

--- a/src/brake/kia_soul_ev_niro/brake_module.rs
+++ b/src/brake/kia_soul_ev_niro/brake_module.rs
@@ -13,6 +13,7 @@ use nucleo_f767zi::hal::prelude::*;
 use num;
 use oscc_magic_byte::*;
 use vehicle::*;
+use super::types::*;
 
 // TODO - use some form of println! logging that prefixes with a module name?
 
@@ -39,10 +40,12 @@ pub struct BrakeModule {
     operator_override_state: FaultCondition,
     brake_report: OsccBrakeReport,
     fault_report_frame: OsccFaultReportFrame,
+    brake_dac: BrakeDac,
+    brake_pins: BrakePins,
 }
 
 impl BrakeModule {
-    pub fn new() -> Self {
+    pub fn new(brake_dac:BrakeDac, brake_pins:BrakePins) -> Self {
         BrakeModule {
             brake_pedal_position: DualSignal::new(
                 0,
@@ -55,12 +58,26 @@ impl BrakeModule {
             operator_override_state: FaultCondition::new(),
             brake_report: OsccBrakeReport::new(),
             fault_report_frame: OsccFaultReportFrame::new(),
+            brake_dac,
+            brake_pins
         }
     }
 
-    pub fn init_devices(&self, board: &mut Board) {
-        board.brake_spoof_enable().set_low();
-        board.brake_light_enable().set_low();
+    pub fn init_devices(&mut self) {
+        self.brake_spoof_enable().set_low();
+        self.brake_light_enable().set_low();
+    }
+
+    fn brake_spoof_enable(&mut self) -> &mut BrakeSpoofEnablePin {
+        &mut self.brake_pins.spoof_enable
+    }
+
+    fn brake_light_enable(&mut self) -> &mut BrakeLightEnablePin {
+        &mut self.brake_pins.brake_light_enable
+    }
+
+    pub fn brake_dac(&mut self) -> &mut BrakeDac {
+        &mut self.brake_dac
     }
 
     pub fn disable_control(&mut self, board: &mut Board) {
@@ -68,13 +85,12 @@ impl BrakeModule {
             self.brake_pedal_position
                 .prevent_signal_discontinuity(board);
 
-            board.brake_dac().output_ab(
-                self.brake_pedal_position.dac_output_a(),
-                self.brake_pedal_position.dac_output_b(),
-            );
+            let a = self.brake_pedal_position.dac_output_a();
+            let b = self.brake_pedal_position.dac_output_b();
+            self.brake_dac().output_ab(a, b);
 
-            board.brake_spoof_enable().set_low();
-            board.brake_light_enable().set_low();
+            self.brake_spoof_enable().set_low();
+            self.brake_light_enable().set_low();
             self.control_state.enabled = false;
             writeln!(board.debug_console, "Brake control disabled");
         }
@@ -85,12 +101,11 @@ impl BrakeModule {
             self.brake_pedal_position
                 .prevent_signal_discontinuity(board);
 
-            board.brake_dac().output_ab(
-                self.brake_pedal_position.dac_output_a(),
-                self.brake_pedal_position.dac_output_b(),
-            );
+            let a = self.brake_pedal_position.dac_output_a();
+            let b = self.brake_pedal_position.dac_output_b();
+            self.brake_dac().output_ab(a, b);
 
-            board.brake_spoof_enable().set_high();
+            self.brake_spoof_enable().set_high();
             self.control_state.enabled = true;
             writeln!(board.debug_console, "Brake control enabled");
         }
@@ -100,7 +115,6 @@ impl BrakeModule {
         &mut self,
         spoof_command_high: u16,
         spoof_command_low: u16,
-        board: &mut Board,
     ) {
         if self.control_state.enabled {
             let spoof_high = num::clamp(
@@ -118,13 +132,13 @@ impl BrakeModule {
             if (spoof_high > BRAKE_LIGHT_SPOOF_HIGH_THRESHOLD)
                 || (spoof_low > BRAKE_LIGHT_SPOOF_LOW_THRESHOLD)
             {
-                board.brake_light_enable().set_high();
+                self.brake_light_enable().set_high();
             } else {
-                board.brake_light_enable().set_low();
+                self.brake_light_enable().set_low();
             }
 
             // TODO - revisit this, enforce high->A, low->B
-            board.brake_dac().output_ab(spoof_high, spoof_low);
+            self.brake_dac().output_ab(spoof_high, spoof_low);
         }
     }
 
@@ -205,7 +219,7 @@ impl BrakeModule {
                 } else if id == OSCC_BRAKE_DISABLE_CAN_ID.into() {
                     self.disable_control(board);
                 } else if id == OSCC_BRAKE_COMMAND_CAN_ID.into() {
-                    self.process_brake_command(&OsccBrakeCommand::from(frame), board);
+                    self.process_brake_command(&OsccBrakeCommand::from(frame));
                 } else if id == OSCC_FAULT_REPORT_CAN_ID.into() {
                     self.process_fault_report(&OsccFaultReport::from(frame), board);
                 }
@@ -223,7 +237,7 @@ impl BrakeModule {
         );
     }
 
-    fn process_brake_command(&mut self, command: &OsccBrakeCommand, board: &mut Board) {
+    fn process_brake_command(&mut self, command: &OsccBrakeCommand) {
         let clamped_position = num::clamp(
             command.pedal_command,
             MINIMUM_BRAKE_COMMAND,
@@ -245,7 +259,7 @@ impl BrakeModule {
         let spoof_value_low = (STEPS_PER_VOLT * spoof_voltage_low) as u16;
         let spoof_value_high = (STEPS_PER_VOLT * spoof_voltage_high) as u16;
 
-        self.update_brake(spoof_value_high, spoof_value_low, board);
+        self.update_brake(spoof_value_high, spoof_value_low);
     }
 
     fn read_brake_pedal_position_sensor(&mut self, board: &mut Board) {

--- a/src/brake/kia_soul_petrol/brake_module.rs
+++ b/src/brake/kia_soul_petrol/brake_module.rs
@@ -14,7 +14,7 @@ impl BrakeModule {
         BrakeModule {}
     }
 
-    pub fn init_devices(&self, board) {
+    pub fn init_devices(&self) {
         board.brake_spoof_enable().set_low();
         board.brake_light_enable().set_low();
         // TODO - PIN_DAC_CHIP_SELECT, HIGH

--- a/src/brake/kia_soul_petrol/brake_module.rs
+++ b/src/brake/kia_soul_petrol/brake_module.rs
@@ -4,16 +4,17 @@
 use board::Board;
 use nucleo_f767zi::hal::can::CanFrame;
 use nucleo_f767zi::hal::prelude::*;
+use super::types::*;
 
 pub struct BrakeModule {}
 
 impl BrakeModule {
-    pub fn new() -> Self {
+    pub fn new(brake_dac:BrakeDac, brake_pins:BrakePins) -> Self {
         panic!("TODO - Kia Soul Petrol brake module not implemented yet");
         BrakeModule {}
     }
 
-    pub fn init_devices(&self, board: &mut Board) {
+    pub fn init_devices(&self, board) {
         board.brake_spoof_enable().set_low();
         board.brake_light_enable().set_low();
         // TODO - PIN_DAC_CHIP_SELECT, HIGH

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ mod brake_module;
 #[path = "brake/kia_soul_petrol/brake_module.rs"]
 mod brake_module;
 
-use board::{hard_fault_indicator, Board};
+use board::{hard_fault_indicator, FullBoard};
 use brake_module::BrakeModule;
 use can_gateway_module::CanGatewayModule;
 use core::fmt::Write;
@@ -73,7 +73,7 @@ entry!(main);
 fn main() -> ! {
     // once the organization is cleaned up, the entire board doesn't need to be
     // mutable let Board {mut leds, mut delay, ..} = Board::new();
-    let mut board = Board::new();
+    let (mut board, brake_dac, brake_pins) = FullBoard::new().split_brake_components();
 
     // turn on the blue LED
     board.leds[led::Color::Blue].on();
@@ -103,12 +103,12 @@ fn main() -> ! {
         }
     }
 
-    let mut brake = BrakeModule::new();
+    let mut brake = BrakeModule::new(brake_dac, brake_pins);
     let mut throttle = ThrottleModule::new();
     let mut steering = SteeringModule::new();
     let mut can_gateway = CanGatewayModule::new();
 
-    brake.init_devices(&mut board);
+    brake.init_devices();
     throttle.init_devices(&mut board);
     steering.init_devices(&mut board);
     can_gateway.init_devices(&mut board);


### PR DESCRIPTION
Here's an example of a rapid way forward -- leave the main board initialization stuff alone, but steadily split off components and hand them to owning modules.