### PR TITLE
Clippy and rustfmt run

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -191,7 +191,7 @@ impl FullBoard {
         unsafe {
             // TODO - move this constant into BSP crate?
             // unlock registers to enable DWT cycle counter for MsTimer
-            core_peripherals.DWT.lar.write(0xC5ACCE55);
+            core_peripherals.DWT.lar.write(0xC5AC_CE55);
         }
 
         let mut leds = Leds::new(led_r, led_g, led_b);
@@ -229,14 +229,14 @@ impl FullBoard {
         ).expect("Failed to configure OBD CAN (CAN2)");
 
         // apply control CAN filters
-        for filter in config::gather_control_can_filters().iter() {
+        for filter in &config::gather_control_can_filters() {
             control_can
                 .configure_filter(&filter)
                 .expect("Failed to configure control CAN filter");
         }
 
         // apply OBD CAN filters
-        for filter in config::gather_obd_can_filters().iter() {
+        for filter in &config::gather_obd_can_filters() {
             obd_can
                 .configure_filter(&filter)
                 .expect("Failed to configure OBD CAN filter");

--- a/src/can_gateway_module.rs
+++ b/src/can_gateway_module.rs
@@ -34,10 +34,8 @@ impl CanGatewayModule {
             }
         }
 
-        if is_a_match {
-            if let Err(_) = board.control_can().transmit(&frame) {
-                // TODO - error handling
-            }
+        if is_a_match && board.control_can().transmit(&frame).is_err() {
+            // TODO - error handling
         }
     }
 }

--- a/src/can_protocols/brake_can_protocol.rs
+++ b/src/can_protocols/brake_can_protocol.rs
@@ -19,13 +19,13 @@ pub struct OsccBrakeCommand {
 
 impl<'a> From<&'a DataFrame> for OsccBrakeCommand {
     fn from(f: &DataFrame) -> Self {
-        assert_eq!(u32::from(f.id()), OSCC_BRAKE_COMMAND_CAN_ID as u32);
+        assert_eq!(u32::from(f.id()), u32::from(OSCC_BRAKE_COMMAND_CAN_ID));
         let data = f.data();
 
-        let raw_brake_request: u32 = data[2] as u32
-            | ((data[3] as u32) << 8)
-            | ((data[4] as u32) << 16)
-            | ((data[5] as u32) << 24);
+        let raw_brake_request: u32 = u32::from(data[2])
+            | (u32::from(data[3]) << 8)
+            | (u32::from(data[4]) << 16)
+            | (u32::from(data[5]) << 24);
 
         OsccBrakeCommand {
             pedal_command: raw_brake_request as f32,
@@ -54,7 +54,7 @@ impl OsccBrakeReport {
     pub fn transmit(&mut self, can: &mut ControlCan) {
         self.update_can_frame();
 
-        if let Err(_) = can.transmit(&self.can_frame.into()) {
+        if can.transmit(&self.can_frame.into()).is_err() {
             // TODO
         }
     }

--- a/src/can_protocols/fault_can_protocol.rs
+++ b/src/can_protocols/fault_can_protocol.rs
@@ -42,13 +42,13 @@ pub struct OsccFaultReportFrame {
 
 impl<'a> From<&'a DataFrame> for OsccFaultReport {
     fn from(f: &DataFrame) -> Self {
-        assert_eq!(u32::from(f.id()), OSCC_FAULT_REPORT_CAN_ID as u32);
+        assert_eq!(u32::from(f.id()), u32::from(OSCC_FAULT_REPORT_CAN_ID));
         let data = f.data();
 
-        let fault_origin_id: u32 = data[2] as u32
-            | ((data[3] as u32) << 8)
-            | ((data[4] as u32) << 16)
-            | ((data[5] as u32) << 24);
+        let fault_origin_id: u32 = u32::from(data[2])
+            | (u32::from(data[3]) << 8)
+            | (u32::from(data[4]) << 16)
+            | (u32::from(data[5]) << 24);
 
         OsccFaultReport {
             fault_origin_id,
@@ -74,7 +74,7 @@ impl OsccFaultReportFrame {
     pub fn transmit(&mut self, can: &mut ControlCan) {
         self.update_can_frame();
 
-        if let Err(_) = can.transmit(&self.can_frame.into()) {
+        if can.transmit(&self.can_frame.into()).is_err() {
             // TODO
         }
     }

--- a/src/can_protocols/steering_can_protocol.rs
+++ b/src/can_protocols/steering_can_protocol.rs
@@ -19,13 +19,13 @@ pub struct OsccSteeringCommand {
 
 impl<'a> From<&'a DataFrame> for OsccSteeringCommand {
     fn from(f: &DataFrame) -> Self {
-        assert_eq!(u32::from(f.id()), OSCC_STEERING_COMMAND_CAN_ID as u32);
+        assert_eq!(u32::from(f.id()), u32::from(OSCC_STEERING_COMMAND_CAN_ID));
         let data = f.data();
 
-        let raw_torque_request: u32 = data[2] as u32
-            | ((data[3] as u32) << 8)
-            | ((data[4] as u32) << 16)
-            | ((data[5] as u32) << 24);
+        let raw_torque_request: u32 = u32::from(data[2])
+            | (u32::from(data[3]) << 8)
+            | (u32::from(data[4]) << 16)
+            | (u32::from(data[5]) << 24);
 
         OsccSteeringCommand {
             torque_request: raw_torque_request as f32,
@@ -54,7 +54,7 @@ impl OsccSteeringReport {
     pub fn transmit(&mut self, can: &mut ControlCan) {
         self.update_can_frame();
 
-        if let Err(_) = can.transmit(&self.can_frame.into()) {
+        if can.transmit(&self.can_frame.into()).is_err() {
             // TODO
         }
     }

--- a/src/can_protocols/throttle_can_protocol.rs
+++ b/src/can_protocols/throttle_can_protocol.rs
@@ -19,13 +19,13 @@ pub struct OsccThrottleCommand {
 
 impl<'a> From<&'a DataFrame> for OsccThrottleCommand {
     fn from(f: &DataFrame) -> Self {
-        assert_eq!(u32::from(f.id()), OSCC_THROTTLE_COMMAND_CAN_ID as u32);
+        assert_eq!(u32::from(f.id()), u32::from(OSCC_THROTTLE_COMMAND_CAN_ID));
         let data = f.data();
 
-        let raw_torque_request: u32 = data[2] as u32
-            | ((data[3] as u32) << 8)
-            | ((data[4] as u32) << 16)
-            | ((data[5] as u32) << 24);
+        let raw_torque_request: u32 = u32::from(data[2])
+            | (u32::from(data[3]) << 8)
+            | (u32::from(data[4]) << 16)
+            | (u32::from(data[5]) << 24);
 
         OsccThrottleCommand {
             torque_request: raw_torque_request as f32,
@@ -54,7 +54,7 @@ impl OsccThrottleReport {
     pub fn transmit(&mut self, can: &mut ControlCan) {
         self.update_can_frame();
 
-        if let Err(_) = can.transmit(&self.can_frame.into()) {
+        if can.transmit(&self.can_frame.into()).is_err() {
             // TODO
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,10 +58,10 @@ pub fn gather_control_can_filters() -> [CanFilterConfig; 3] {
     f0.mode = FilterMode::IdList;
     f0.fifo_assignment = RxFifo::Fifo0;
     f0.scale = FilterScale::Fs16Bit;
-    f0.filter_mask_id_low = (OSCC_THROTTLE_DISABLE_CAN_ID << 5) as _;
-    f0.filter_id_low = (OSCC_BRAKE_DISABLE_CAN_ID << 5) as _;
-    f0.filter_mask_id_high = (OSCC_STEERING_DISABLE_CAN_ID << 5) as _;
-    f0.filter_id_high = (OSCC_FAULT_REPORT_CAN_ID << 5) as _;
+    f0.filter_mask_id_low = u32::from(OSCC_THROTTLE_DISABLE_CAN_ID << 5);
+    f0.filter_id_low = u32::from(OSCC_BRAKE_DISABLE_CAN_ID << 5);
+    f0.filter_mask_id_high = u32::from(OSCC_STEERING_DISABLE_CAN_ID << 5);
+    f0.filter_id_high = u32::from(OSCC_FAULT_REPORT_CAN_ID << 5);
 
     // filter 1 stores the control command IDs for brake, throttle, and steering
     // FIFO_1
@@ -71,9 +71,9 @@ pub fn gather_control_can_filters() -> [CanFilterConfig; 3] {
     f1.mode = FilterMode::IdList;
     f1.fifo_assignment = RxFifo::Fifo1;
     f1.scale = FilterScale::Fs16Bit;
-    f1.filter_mask_id_low = (OSCC_BRAKE_COMMAND_CAN_ID << 5) as _;
-    f1.filter_id_low = (OSCC_THROTTLE_COMMAND_CAN_ID << 5) as _;
-    f1.filter_mask_id_high = (OSCC_STEERING_COMMAND_CAN_ID << 5) as _;
+    f1.filter_mask_id_low = u32::from(OSCC_BRAKE_COMMAND_CAN_ID << 5);
+    f1.filter_id_low = u32::from(OSCC_THROTTLE_COMMAND_CAN_ID << 5);
+    f1.filter_mask_id_high = u32::from(OSCC_STEERING_COMMAND_CAN_ID << 5);
     f1.filter_id_high = 0;
 
     // filter 2 stores the enable control IDs for brake, throttle, and steering
@@ -84,9 +84,9 @@ pub fn gather_control_can_filters() -> [CanFilterConfig; 3] {
     f2.mode = FilterMode::IdList;
     f2.fifo_assignment = RxFifo::Fifo1;
     f2.scale = FilterScale::Fs16Bit;
-    f2.filter_mask_id_low = (OSCC_BRAKE_ENABLE_CAN_ID << 5) as _;
-    f2.filter_id_low = (OSCC_THROTTLE_ENABLE_CAN_ID << 5) as _;
-    f2.filter_mask_id_high = (OSCC_STEERING_ENABLE_CAN_ID << 5) as _;
+    f2.filter_mask_id_low = u32::from(OSCC_BRAKE_ENABLE_CAN_ID << 5);
+    f2.filter_id_low = u32::from(OSCC_THROTTLE_ENABLE_CAN_ID << 5);
+    f2.filter_mask_id_high = u32::from(OSCC_STEERING_ENABLE_CAN_ID << 5);
     f2.filter_id_high = 0;
 
     [f0, f1, f2]
@@ -103,12 +103,12 @@ pub fn gather_obd_can_filters() -> [CanFilterConfig; 1] {
     f3.mode = FilterMode::IdList;
     f3.fifo_assignment = RxFifo::Fifo0;
     f3.scale = FilterScale::Fs16Bit;
-    f3.filter_mask_id_low = (KIA_SOUL_OBD_STEERING_WHEEL_ANGLE_CAN_ID << 5) as _;
-    f3.filter_id_low = (KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID << 5) as _;
-    f3.filter_mask_id_high = (KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID << 5) as _;
+    f3.filter_mask_id_low = u32::from(KIA_SOUL_OBD_STEERING_WHEEL_ANGLE_CAN_ID << 5);
+    f3.filter_id_low = u32::from(KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID << 5);
+    f3.filter_mask_id_high = u32::from(KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID << 5);
     #[cfg(feature = "kia-soul-ev")]
     {
-        f3.filter_id_high = (KIA_SOUL_OBD_THROTTLE_PRESSURE_CAN_ID << 5) as _;
+        f3.filter_id_high = u32::from(KIA_SOUL_OBD_THROTTLE_PRESSURE_CAN_ID << 5);
     }
 
     [f3]

--- a/src/dac_mcp4922.rs
+++ b/src/dac_mcp4922.rs
@@ -48,8 +48,7 @@ where
         let mut buffer = [0u8; 2];
         // bits 11 through 0: data
         buffer[0] = (data & 0x00FF) as _;
-        buffer[1] = 0x00
-            | ((data >> 8) & 0x000F) as u8
+        buffer[1] = ((data >> 8) & 0x000F) as u8
             // bit 12: shutdown bit. 1 for active operation
             | (1 << 4)
             // bit 13: gain bit; 0 for 1x gain, 1 for 2x
@@ -57,7 +56,7 @@ where
             // bit 15: 0 for DAC A, 1 for DAC B
             | u8::from(channel) << 7;
 
-        if let Err(_) = self.spi.transfer(&mut buffer) {
+        if self.spi.transfer(&mut buffer).is_err() {
             // TODO - error handling
         }
 

--- a/src/dual_signal.rs
+++ b/src/dual_signal.rs
@@ -32,11 +32,11 @@ where
         let mut high: u32 = 0;
 
         for _ in 0..DAC_SAMPLE_AVERAGE_COUNT {
-            low += self.reader.read_low() as u32;
+            low += u32::from(self.reader.read_low());
         }
 
         for _ in 0..DAC_SAMPLE_AVERAGE_COUNT {
-            high += self.reader.read_high() as u32;
+            high += u32::from(self.reader.read_high());
         }
 
         self.low = (low / DAC_SAMPLE_AVERAGE_COUNT) as _;
@@ -44,11 +44,11 @@ where
     }
 
     pub fn average(&self) -> u32 {
-        (self.low as u32 + self.high as u32) / 2
+        (u32::from(self.low) + u32::from(self.high)) / 2
     }
 
     pub fn diff(&self) -> u16 {
-        num::abs((self.high as i32) - (self.low as i32)) as u16
+        num::abs(i32::from(self.high) - i32::from(self.low)) as u16
     }
 
     pub fn high(&self) -> u16 {

--- a/src/steering_module.rs
+++ b/src/steering_module.rs
@@ -134,8 +134,8 @@ impl SteeringModule {
             // OSCC goes back and forth with u16 and f32 types
             self.filtered_diff = self.exponential_moving_average(
                 FILTER_ALPHA,
-                unfiltered_diff as _,
-                self.filtered_diff as _,
+                f32::from(unfiltered_diff),
+                f32::from(self.filtered_diff),
             ) as _;
 
             let inputs_grounded: bool = self.grounded_fault_state.check_voltage_grounded(
@@ -152,8 +152,9 @@ impl SteeringModule {
                     .dtcs
                     .set(OSCC_STEERING_DTC_INVALID_SENSOR_VAL);
 
-                if let Err(_) =
-                    fault_report_publisher.publish_fault_report(self.supply_fault_report())
+                if fault_report_publisher
+                    .publish_fault_report(self.supply_fault_report())
+                    .is_err()
                 {
                     // TODO - publish error handling
                 }
@@ -174,8 +175,9 @@ impl SteeringModule {
                     .dtcs
                     .set(OSCC_STEERING_DTC_OPERATOR_OVERRIDE);
 
-                if let Err(_) =
-                    fault_report_publisher.publish_fault_report(self.supply_fault_report())
+                if fault_report_publisher
+                    .publish_fault_report(self.supply_fault_report())
+                    .is_err()
                 {
                     // TODO - publish error handling
                 }

--- a/src/throttle_module.rs
+++ b/src/throttle_module.rs
@@ -32,7 +32,7 @@ where
         ThrottleControlState {
             enabled: false,
             operator_override: false,
-            dtcs: dtcs,
+            dtcs,
         }
     }
 }


### PR DESCRIPTION
Resolves most clippy complaints, hopefully not at the cost of any equivalence problems.

The only new functionality is printing to the debug console if a CAN receive fails in the main loop.