### PR TITLE
Align vehicle ADC domain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 [[package]]
 name = "stm32f767-hal"
 version = "0.0.1"
-source = "git+https://github.com/jonlamb-gh/stm32f767-hal.git?branch=devel#fdd4bd638f69c04a3886acb17039c685fa32aa14"
+source = "git+https://github.com/jonlamb-gh/stm32f767-hal.git?branch=devel#eb667d5ef38cc0eb0a307bff35cb8c32fb2ec5b6"
 dependencies = [
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortex-m 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/vehicles/kial_niro.rs
+++ b/src/vehicles/kial_niro.rs
@@ -159,7 +159,7 @@ pub const fn brake_position_to_volts_high(position: f32) -> f32 {
  * override. [steps] */
 //
 //
-pub const BRAKE_PEDAL_OVERRIDE_THRESHOLD: u16 = 200;
+pub const BRAKE_PEDAL_OVERRIDE_THRESHOLD: u16 = 200 << 2;
 
 /*
  * @brief Minimum value of the high spoof signal that activates the brake
@@ -387,4 +387,4 @@ pub const fn throttle_position_to_volts_high(position: f32) -> f32 {
  * override. [steps] */
 //
 //
-pub const ACCELERATOR_OVERRIDE_THRESHOLD: u32 = 185;
+pub const ACCELERATOR_OVERRIDE_THRESHOLD: u32 = 185 << 2;

--- a/src/vehicles/kial_soul_ev.rs
+++ b/src/vehicles/kial_soul_ev.rs
@@ -159,7 +159,7 @@ pub const fn brake_position_to_volts_high(position: f32) -> f32 {
  * override. [steps] */
 //
 //
-pub const BRAKE_PEDAL_OVERRIDE_THRESHOLD: u16 = 130;
+pub const BRAKE_PEDAL_OVERRIDE_THRESHOLD: u16 = 130 << 2;
 
 /*
  * @brief Minimum value of the low spoof signal that activates the brake
@@ -387,4 +387,4 @@ pub const fn throttle_position_to_volts_high(position: f32) -> f32 {
  * override. [steps] */
 //
 //
-pub const ACCELERATOR_OVERRIDE_THRESHOLD: u32 = 185;
+pub const ACCELERATOR_OVERRIDE_THRESHOLD: u32 = 185 << 2;

--- a/src/vehicles/kial_soul_petrol.rs
+++ b/src/vehicles/kial_soul_petrol.rs
@@ -449,4 +449,4 @@ pub const fn throttle_position_to_volts_high(position: f32) -> f32 {
  * override. [steps] */
 //
 //
-pub const ACCELERATOR_OVERRIDE_THRESHOLD: u32 = 185;
+pub const ACCELERATOR_OVERRIDE_THRESHOLD: u32 = 185 << 2;


### PR DESCRIPTION
Enable ADC clock prescaler so we can adjust ADC sample time once we have some ability to test things.

This also aligns the 10 bit constants to 12 bits.