### PR TITLE
More type staging and encapsulation

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -233,7 +233,7 @@ impl FullBoard {
             (can1_tx, can1_rx),
             &mut rcc.apb1,
             &config::CONTROL_CAN_CONFIG,
-        ).expect("Failed to configure ontrol CAN (CAN1)");
+        ).expect("Failed to configure control CAN (CAN1)");
 
         let obd_can = Can::can2(
             peripherals.CAN2,

--- a/src/board.rs
+++ b/src/board.rs
@@ -3,12 +3,10 @@ use cortex_m;
 use dac_mcp4922::Mcp4922;
 use dac_mcp4922::MODE as DAC_MODE;
 use dual_signal::HighLowReader;
-use fault_can_protocol::*;
 use ms_timer::MsTimer;
 use nucleo_f767zi::debug_console::DebugConsole;
 use nucleo_f767zi::hal::adc::{Adc, AdcChannel, AdcPrescaler, AdcSampleTime};
-use nucleo_f767zi::hal::can::{Can, CanError, DataFrame};
-use nucleo_f767zi::hal::delay::Delay;
+use nucleo_f767zi::hal::can::Can;
 use nucleo_f767zi::hal::iwdg::{Iwdg, IwdgConfig, WatchdogTimeout};
 use nucleo_f767zi::hal::prelude::*;
 use nucleo_f767zi::hal::rcc::ResetConditions;
@@ -18,7 +16,6 @@ use nucleo_f767zi::hal::stm32f7x7;
 use nucleo_f767zi::hal::stm32f7x7::{ADC1, ADC2, ADC3, IWDG};
 use nucleo_f767zi::led::{Color, Leds};
 use nucleo_f767zi::UserButtonPin;
-use oscc_magic_byte::*;
 
 pub use types::*;
 
@@ -53,7 +50,6 @@ pub struct FullBoard {
     pub debug_console: DebugConsole,
     pub leds: Leds,
     pub user_button: UserButtonPin,
-    pub delay: Delay,
     pub timer_ms: MsTimer,
     pub can_publish_timer: CanPublishTimer,
     pub wdg: Iwdg<IWDG>,
@@ -74,13 +70,8 @@ pub struct FullBoard {
 pub struct Board {
     pub leds: Leds,
     pub user_button: UserButtonPin,
-    pub delay: Delay,
-    pub can_publish_timer: CanPublishTimer,
     pub wdg: Iwdg<IWDG>,
     pub reset_conditions: ResetConditions,
-    control_can: ControlCan,
-    obd_can: ObdCan,
-    fault_report_can_frame: DataFrame,
 }
 
 impl FullBoard {
@@ -289,7 +280,6 @@ impl FullBoard {
             user_button: gpioc
                 .pc13
                 .into_pull_down_input(&mut gpioc.moder, &mut gpioc.pupdr),
-            delay: Delay::new(core_peripherals.SYST, clocks),
             timer_ms: MsTimer::new(core_peripherals.DWT, clocks),
             can_publish_timer: CanPublishTimer::tim2(
                 peripherals.TIM2,
@@ -337,12 +327,14 @@ impl FullBoard {
         SteeringPins,
         MsTimer,
         DebugConsole,
+        CanPublishTimer,
+        ControlCan,
+        ObdCan,
     ) {
         let FullBoard {
             debug_console,
             leds,
             user_button,
-            delay,
             timer_ms,
             can_publish_timer,
             wdg,
@@ -363,13 +355,8 @@ impl FullBoard {
             Board {
                 leds,
                 user_button,
-                delay,
-                can_publish_timer,
                 wdg,
                 reset_conditions,
-                control_can,
-                obd_can,
-                fault_report_can_frame: default_fault_report_data_frame(),
             },
             brake_dac,
             brake_pins,
@@ -382,6 +369,9 @@ impl FullBoard {
             steering_pins,
             timer_ms,
             debug_console,
+            can_publish_timer,
+            control_can,
+            obd_can,
         )
     }
 }
@@ -389,14 +379,6 @@ impl FullBoard {
 impl Board {
     pub fn user_button(&mut self) -> bool {
         self.user_button.is_high()
-    }
-
-    pub fn control_can(&mut self) -> &mut ControlCan {
-        &mut self.control_can
-    }
-
-    pub fn obd_can(&mut self) -> &mut ObdCan {
-        &mut self.obd_can
     }
 }
 
@@ -439,28 +421,6 @@ impl HighLowReader for TorqueSensor {
     }
     fn read_low(&self) -> u16 {
         self.adc3.read(AdcChannel::Adc3In8, ADC_SAMPLE_TIME)
-    }
-}
-
-impl FaultReportPublisher for Board {
-    fn publish_fault_report(&mut self, fault_report: &OsccFaultReport) -> Result<(), CanError> {
-        {
-            self.fault_report_can_frame
-                .set_data_length(OSCC_FAULT_REPORT_CAN_DLC as _);
-
-            let data = self.fault_report_can_frame.data_as_mut();
-
-            data[0] = OSCC_MAGIC_BYTE_0;
-            data[1] = OSCC_MAGIC_BYTE_1;
-            data[2] = (fault_report.fault_origin_id & 0xFF) as _;
-            data[3] = ((fault_report.fault_origin_id >> 8) & 0xFF) as _;
-            data[4] = ((fault_report.fault_origin_id >> 16) & 0xFF) as _;
-            data[5] = ((fault_report.fault_origin_id >> 24) & 0xFF) as _;
-            data[6] = fault_report.dtcs;
-        }
-
-        self.control_can
-            .transmit(&self.fault_report_can_frame.into())
     }
 }
 

--- a/src/can_gateway_module.rs
+++ b/src/can_gateway_module.rs
@@ -1,22 +1,45 @@
 // https://github.com/jonlamb-gh/oscc/tree/devel/firmware/can_gateway
 
-use board::Board;
-use nucleo_f767zi::hal::can::CanFrame;
+use fault_can_protocol::*;
+use nucleo_f767zi::hal::can::{CanError, CanFrame, DataFrame, RxFifo};
+use nucleo_f767zi::hal::prelude::*;
+use oscc_magic_byte::*;
+use types::*;
 use vehicle::*;
 
 // TODO - use some form of println! logging that prefixes with a module name?
 
-pub struct CanGatewayModule {}
+pub struct CanGatewayModule {
+    can_publish_timer: CanPublishTimer,
+    control_can: ControlCan,
+    obd_can: ObdCan,
+    fault_report_can_frame: DataFrame,
+}
 
 impl CanGatewayModule {
-    pub fn new() -> Self {
-        CanGatewayModule {}
+    pub fn new(
+        can_publish_timer: CanPublishTimer,
+        control_can: ControlCan,
+        obd_can: ObdCan,
+    ) -> Self {
+        CanGatewayModule {
+            can_publish_timer,
+            control_can,
+            obd_can,
+            fault_report_can_frame: default_fault_report_data_frame(),
+        }
+    }
+    pub fn republish_obd_frames_to_control_can_bus(&mut self) {
+        // poll both OBD CAN FIFOs
+        for fifo in &[RxFifo::Fifo0, RxFifo::Fifo1] {
+            if let Ok(rx_frame) = self.obd_can().receive(fifo) {
+                self.republish_obd_frame_to_control_can_bus(&rx_frame);
+            }
+        }
     }
 
-    pub fn init_devices(&self, _board: &mut Board) {}
-
     // TODO - error handling
-    pub fn republish_obd_frame_to_control_can_bus(&mut self, frame: &CanFrame, board: &mut Board) {
+    fn republish_obd_frame_to_control_can_bus(&mut self, frame: &CanFrame) {
         let id: u32 = frame.id().into();
         let mut is_a_match = false;
 
@@ -34,8 +57,43 @@ impl CanGatewayModule {
             }
         }
 
-        if is_a_match && board.control_can().transmit(&frame).is_err() {
+        if is_a_match && self.control_can().transmit(&frame).is_err() {
             // TODO - error handling
         }
+    }
+
+    // TODO - hide these details, switch to a publisher approach
+    pub fn control_can(&mut self) -> &mut ControlCan {
+        &mut self.control_can
+    }
+
+    pub fn obd_can(&mut self) -> &mut ObdCan {
+        &mut self.obd_can
+    }
+
+    pub fn wait_for_publish(&mut self) -> bool {
+        self.can_publish_timer.wait().is_ok()
+    }
+}
+
+impl FaultReportPublisher for CanGatewayModule {
+    fn publish_fault_report(&mut self, fault_report: &OsccFaultReport) -> Result<(), CanError> {
+        {
+            self.fault_report_can_frame
+                .set_data_length(OSCC_FAULT_REPORT_CAN_DLC as _);
+
+            let data = self.fault_report_can_frame.data_as_mut();
+
+            data[0] = OSCC_MAGIC_BYTE_0;
+            data[1] = OSCC_MAGIC_BYTE_1;
+            data[2] = (fault_report.fault_origin_id & 0xFF) as _;
+            data[3] = ((fault_report.fault_origin_id >> 8) & 0xFF) as _;
+            data[4] = ((fault_report.fault_origin_id >> 16) & 0xFF) as _;
+            data[5] = ((fault_report.fault_origin_id >> 24) & 0xFF) as _;
+            data[6] = fault_report.dtcs;
+        }
+
+        self.control_can
+            .transmit(&self.fault_report_can_frame.into())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ use nucleo_f767zi::hal::prelude::*;
 use nucleo_f767zi::led;
 use rt::ExceptionFrame;
 use steering_module::SteeringModule;
-use throttle_module::ThrottleModule;
+use throttle_module::UnpreparedThrottleModule;
 
 const DEBUG_WRITE_FAILURE: &str = "Failed to write to debug_console";
 
@@ -120,13 +120,13 @@ fn main() -> ! {
     }
 
     let mut brake = BrakeModule::new(brake_dac, brake_pins, brake_pedal_position_sensor);
-    let mut throttle =
-        ThrottleModule::new(accelerator_position_sensor, throttle_dac, throttle_pins);
+    let unprepared_throttle_module =
+        UnpreparedThrottleModule::new(accelerator_position_sensor, throttle_dac, throttle_pins);
     let mut steering = SteeringModule::new(torque_sensor, steering_dac, steering_pins);
     let mut can_gateway = CanGatewayModule::new();
 
     brake.init_devices();
-    throttle.init_devices();
+    let mut throttle = unprepared_throttle_module.prepare_module();
     steering.init_devices();
     can_gateway.init_devices(&mut board);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,6 @@ use can_gateway_module::CanGatewayModule;
 use core::fmt::Write;
 use fault_can_protocol::FaultReportPublisher;
 use nucleo_f767zi::hal::can::RxFifo;
-use nucleo_f767zi::hal::prelude::*;
 use nucleo_f767zi::led;
 use rt::ExceptionFrame;
 use steering_module::SteeringModule;
@@ -88,6 +87,9 @@ fn main() -> ! {
         steering_pins,
         timer_ms,
         mut debug_console,
+        can_publish_timer,
+        control_can,
+        obd_can,
     ) = FullBoard::new().split_components();
 
     // turn on the blue LED
@@ -123,17 +125,16 @@ fn main() -> ! {
     let unprepared_throttle_module =
         UnpreparedThrottleModule::new(accelerator_position_sensor, throttle_dac, throttle_pins);
     let mut steering = SteeringModule::new(torque_sensor, steering_dac, steering_pins);
-    let mut can_gateway = CanGatewayModule::new();
+    let mut can_gateway = CanGatewayModule::new(can_publish_timer, control_can, obd_can);
 
     brake.init_devices();
     let mut throttle = unprepared_throttle_module.prepare_module();
     steering.init_devices();
-    can_gateway.init_devices(&mut board);
 
     // send reports immediately
-    brake.publish_brake_report(&mut board);
-    throttle.publish_throttle_report(&mut board);
-    steering.publish_steering_report(&mut board);
+    brake.publish_brake_report(&mut can_gateway);
+    throttle.publish_throttle_report(&mut can_gateway);
+    steering.publish_steering_report(&mut can_gateway);
 
     loop {
         // refresh the independent watchdog
@@ -141,7 +142,7 @@ fn main() -> ! {
 
         // poll both control CAN FIFOs
         for fifo in &[RxFifo::Fifo0, RxFifo::Fifo1] {
-            match board.control_can().receive(fifo) {
+            match can_gateway.control_can().receive(fifo) {
                 Ok(rx_frame) => {
                     brake.process_rx_frame(&rx_frame, &mut debug_console);
                     throttle.process_rx_frame(&rx_frame, &mut debug_console);
@@ -152,28 +153,23 @@ fn main() -> ! {
             }
         }
 
-        brake.check_for_faults(&timer_ms, &mut debug_console, &mut board);
+        brake.check_for_faults(&timer_ms, &mut debug_console, &mut can_gateway);
         if let Some(throttle_fault) = throttle.check_for_faults(&timer_ms, &mut debug_console) {
-            let _ = board.publish_fault_report(throttle_fault); // TODO - high-level publish error handling
+            let _ = can_gateway.publish_fault_report(throttle_fault); // TODO - high-level publish error handling
         }
-        steering.check_for_faults(&timer_ms, &mut debug_console, &mut board);
+        steering.check_for_faults(&timer_ms, &mut debug_console, &mut can_gateway);
 
-        // poll both OBD CAN FIFOs
-        for fifo in &[RxFifo::Fifo0, RxFifo::Fifo1] {
-            if let Ok(rx_frame) = board.obd_can().receive(fifo) {
-                can_gateway.republish_obd_frame_to_control_can_bus(&rx_frame, &mut board);
-            }
-        }
+        can_gateway.republish_obd_frames_to_control_can_bus();
 
         // TODO - just polling the publish timer for now
         // we can also drive this logic from the interrupt
         // handler if the objects are global and atomic
-        if board.can_publish_timer.wait().is_ok() {
+        if can_gateway.wait_for_publish() {
             board.leds[led::Color::Green].toggle();
 
-            brake.publish_brake_report(&mut board);
-            throttle.publish_throttle_report(&mut board);
-            steering.publish_steering_report(&mut board);
+            brake.publish_brake_report(&mut can_gateway);
+            throttle.publish_throttle_report(&mut can_gateway);
+            steering.publish_steering_report(&mut can_gateway);
         }
 
         // TODO - do anything with the user button?

--- a/src/steering_module.rs
+++ b/src/steering_module.rs
@@ -1,6 +1,7 @@
 // https://github.com/jonlamb-gh/oscc/tree/devel/firmware/steering
 
-use board::{Board, TorqueSensor};
+use board::TorqueSensor;
+use can_gateway_module::CanGatewayModule;
 use core::fmt::Write;
 use dtc::DtcBitfield;
 use dual_signal::DualSignal;
@@ -196,12 +197,13 @@ impl SteeringModule {
         (alpha * input) + ((1.0 - alpha) * average)
     }
 
-    pub fn publish_steering_report(&mut self, board: &mut Board) {
+    pub fn publish_steering_report(&mut self, can_gateway: &mut CanGatewayModule) {
         self.steering_report.enabled = self.control_state.enabled;
         self.steering_report.operator_override = self.control_state.operator_override;
         self.steering_report.dtcs = self.control_state.dtcs;
 
-        self.steering_report.transmit(&mut board.control_can());
+        self.steering_report
+            .transmit(&mut can_gateway.control_can());
     }
 
     fn supply_fault_report(&mut self) -> &OsccFaultReport {

--- a/src/throttle_module.rs
+++ b/src/throttle_module.rs
@@ -1,6 +1,7 @@
 // https://github.com/jonlamb-gh/oscc/tree/devel/firmware/throttle
 
-use board::{AcceleratorPositionSensor, Board};
+use board::AcceleratorPositionSensor;
+use can_gateway_module::CanGatewayModule;
 use core::fmt::Write;
 use dtc::DtcBitfield;
 use dual_signal::DualSignal;
@@ -53,7 +54,7 @@ pub struct UnpreparedThrottleModule {
 }
 
 impl UnpreparedThrottleModule {
-    pub fn new (
+    pub fn new(
         accelerator_position_sensor: AcceleratorPositionSensor,
         throttle_dac: ThrottleDac,
         throttle_pins: ThrottlePins,
@@ -83,7 +84,6 @@ impl UnpreparedThrottleModule {
 }
 
 impl ThrottleModule {
-
     fn disable_control(&mut self, debug_console: &mut DebugConsole) {
         if self.control_state.enabled {
             self.accelerator_position.prevent_signal_discontinuity();
@@ -199,12 +199,13 @@ impl ThrottleModule {
         }
     }
 
-    pub fn publish_throttle_report(&mut self, board: &mut Board) {
+    pub fn publish_throttle_report(&mut self, can_gateway: &mut CanGatewayModule) {
         self.throttle_report.enabled = self.control_state.enabled;
         self.throttle_report.operator_override = self.control_state.operator_override;
         self.throttle_report.dtcs = self.control_state.dtcs;
 
-        self.throttle_report.transmit(&mut board.control_can());
+        self.throttle_report
+            .transmit(&mut can_gateway.control_can());
     }
 
     fn update_fault_report(&mut self) {


### PR DESCRIPTION
1) Make it so that the throttle module can't be used until it is prepared/initialized to a desired state.
2) Move the CAN devices into the CanGatewayModule (does *not* include all of the relevant publish-pattern refactoring demonstrated earlier)
3) Hides the nitty-gritty of the OBD/Control CAN republishing.  If we want to make interception/rewriting visible to the main loop, this will require refactoring.