### PR TITLE
Use type-based ranges for DAC outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic-abort 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic-semihosting 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -186,6 +187,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vcell"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +232,7 @@ dependencies = [
 "checksum r0 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
 "checksum stm32f7 0.2.2 (git+https://github.com/jonlamb-gh/stm32-rs.git?branch=stm32f767zit6-patches)" = "<none>"
 "checksum stm32f767-hal 0.0.1 (git+https://github.com/jonlamb-gh/stm32f767-hal.git?branch=devel)" = "<none>"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum vcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45c297f0afb6928cd08ab1ff9d95e99392595ea25ae1b5ecf822ff8764e57a0d"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum volatile-register 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ default-features = false
 features = ["unproven"]
 version = "0.2.0"
 
+[dependencies.typenum]
+version = "1.1.0"
+default-features = false
+
 [profile.release]
 codegen-units = 1 # better optimizations
 lto = true # better optimizations

--- a/src/brake/kia_soul_ev_niro/brake_module.rs
+++ b/src/brake/kia_soul_ev_niro/brake_module.rs
@@ -120,8 +120,8 @@ impl BrakeModule {
             let spoof_high = BrakeSpoofHighSignal::clamp(spoof_command_high);
             let spoof_low = BrakeSpoofLowSignal::clamp(spoof_command_low);
 
-            if (spoof_high.val > BRAKE_LIGHT_SPOOF_HIGH_THRESHOLD)
-                || (spoof_low.val > BRAKE_LIGHT_SPOOF_LOW_THRESHOLD)
+            if (spoof_high.val() > &BRAKE_LIGHT_SPOOF_HIGH_THRESHOLD)
+                || (spoof_low.val() > &BRAKE_LIGHT_SPOOF_LOW_THRESHOLD)
             {
                 self.brake_pins.brake_light_enable.set_high();
             } else {

--- a/src/brake/kia_soul_ev_niro/brake_module.rs
+++ b/src/brake/kia_soul_ev_niro/brake_module.rs
@@ -4,6 +4,7 @@ use super::types::*;
 use board::BrakePedalPositionSensor;
 use brake_can_protocol::*;
 use core::fmt::Write;
+use dac_mcp4922::DacOutput;
 use dtc::DtcBitfield;
 use dual_signal::DualSignal;
 use fault_can_protocol::*;
@@ -14,6 +15,7 @@ use nucleo_f767zi::hal::can::CanFrame;
 use nucleo_f767zi::hal::prelude::*;
 use num;
 use oscc_magic_byte::*;
+use ranges;
 use vehicle::*;
 
 struct BrakeControlState<DTCS: DtcBitfield> {
@@ -87,8 +89,8 @@ impl BrakeModule {
             self.brake_pedal_position.prevent_signal_discontinuity();
 
             self.brake_dac.output_ab(
-                self.brake_pedal_position.low(),
-                self.brake_pedal_position.high(),
+                DacOutput::clamp(self.brake_pedal_position.low()),
+                DacOutput::clamp(self.brake_pedal_position.high()),
             );
 
             self.brake_pins.spoof_enable.set_low();
@@ -103,8 +105,8 @@ impl BrakeModule {
             self.brake_pedal_position.prevent_signal_discontinuity();
 
             self.brake_dac.output_ab(
-                self.brake_pedal_position.low(),
-                self.brake_pedal_position.high(),
+                DacOutput::clamp(self.brake_pedal_position.low()),
+                DacOutput::clamp(self.brake_pedal_position.high()),
             );
 
             self.brake_pins.spoof_enable.set_high();
@@ -115,20 +117,11 @@ impl BrakeModule {
 
     fn update_brake(&mut self, spoof_command_high: u16, spoof_command_low: u16) {
         if self.control_state.enabled {
-            let spoof_high = num::clamp(
-                spoof_command_high,
-                BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MIN,
-                BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MAX,
-            );
+            let spoof_high = BrakeSpoofHighSignal::clamp(spoof_command_high);
+            let spoof_low = BrakeSpoofLowSignal::clamp(spoof_command_low);
 
-            let spoof_low = num::clamp(
-                spoof_command_low,
-                BRAKE_SPOOF_LOW_SIGNAL_RANGE_MIN,
-                BRAKE_SPOOF_LOW_SIGNAL_RANGE_MAX,
-            );
-
-            if (spoof_high > BRAKE_LIGHT_SPOOF_HIGH_THRESHOLD)
-                || (spoof_low > BRAKE_LIGHT_SPOOF_LOW_THRESHOLD)
+            if (spoof_high.val > BRAKE_LIGHT_SPOOF_HIGH_THRESHOLD)
+                || (spoof_low.val > BRAKE_LIGHT_SPOOF_LOW_THRESHOLD)
             {
                 self.brake_pins.brake_light_enable.set_high();
             } else {
@@ -136,7 +129,8 @@ impl BrakeModule {
             }
 
             // TODO - revisit this, enforce high->A, low->B
-            self.brake_dac.output_ab(spoof_high, spoof_low);
+            self.brake_dac
+                .output_ab(ranges::coerce(spoof_high), ranges::coerce(spoof_low));
         }
     }
 

--- a/src/dac_mcp4922.rs
+++ b/src/dac_mcp4922.rs
@@ -55,8 +55,8 @@ where
 
         let mut buffer = [0u8; 2];
         // bits 11 through 0: data
-        buffer[0] = (data.val & 0x00FF) as _;
-        buffer[1] = ((data.val >> 8) & 0x000F) as u8
+        buffer[0] = (data.val() & 0x00FF) as _;
+        buffer[1] = ((data.val() >> 8) & (0x000F as u16)) as u8
             // bit 12: shutdown bit. 1 for active operation
             | (1 << 4)
             // bit 13: gain bit; 0 for 1x gain, 1 for 2x

--- a/src/dac_mcp4922.rs
+++ b/src/dac_mcp4922.rs
@@ -7,6 +7,14 @@ use embedded_hal::blocking::spi::Transfer;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{Mode, Phase, Polarity};
 
+use ranges::Bounded;
+use typenum::{U0, U1, U4096};
+
+type U4095 = op! { U4096 - U1 };
+
+/// It's a 12 bit dac, so the upper bound is 4095 (2^12 - 1)
+pub type DacOutput = Bounded<u16, U0, U4095>;
+
 /// SPI mode
 pub const MODE: Mode = Mode {
     phase: Phase::CaptureOnFirstTransition,
@@ -36,19 +44,19 @@ where
         Mcp4922 { spi, cs }
     }
 
-    pub fn output_ab(&mut self, output_a: u16, output_b: u16) {
+    pub fn output_ab(&mut self, output_a: DacOutput, output_b: DacOutput) {
         // TODO latching?
         self.output(output_a, Channel::ChannelA);
         self.output(output_b, Channel::ChannelB);
     }
 
-    pub fn output(&mut self, data: u16, channel: Channel) {
+    pub fn output(&mut self, data: DacOutput, channel: Channel) {
         self.cs.set_low();
 
         let mut buffer = [0u8; 2];
         // bits 11 through 0: data
-        buffer[0] = (data & 0x00FF) as _;
-        buffer[1] = ((data >> 8) & 0x000F) as u8
+        buffer[0] = (data.val & 0x00FF) as _;
+        buffer[1] = ((data.val >> 8) & 0x000F) as u8
             // bit 12: shutdown bit. 1 for active operation
             | (1 << 4)
             // bit 13: gain bit; 0 for 1x gain, 1 for 2x

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ extern crate num;
 extern crate panic_abort;
 #[cfg(feature = "panic-over-semihosting")]
 extern crate panic_semihosting;
+#[macro_use]
+extern crate typenum;
 
 mod board;
 mod can_gateway_module;
@@ -26,6 +28,7 @@ mod ms_timer;
 mod steering_module;
 mod throttle_module;
 mod types;
+mod ranges;
 
 #[path = "can_protocols/brake_can_protocol.rs"]
 mod brake_can_protocol;

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -26,7 +26,7 @@ impl<T: Unsigned> ReifyTo<u16> for T {
 
 #[derive(Debug)]
 pub struct Bounded<T,L,U> {
-    pub val: T,
+    val: T,
     _lower_inclusive: PhantomData<L>,
     _upper_inclusive: PhantomData<U>,
 }
@@ -38,6 +38,10 @@ impl<T: PartialOrd, L: ReifyTo<T>, U: ReifyTo<T>> Bounded<T,L,U> {
             _lower_inclusive: PhantomData,
             _upper_inclusive: PhantomData
         }
+    }
+
+    pub fn val(&self) -> &T {
+        &self.val
     }
 }
 

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -1,0 +1,77 @@
+use core::marker::PhantomData;
+use num;
+
+use typenum::{Unsigned, Cmp, B1, Same};
+// Although this says private, it's needed to write generic inequality
+// constraints for typenums
+use typenum::private::IsLessOrEqualPrivate;
+
+/// Indicates that a type-level number may be converted to a runtime-level
+/// number of the type T
+pub trait ReifyTo<T> {
+    fn reify() -> T;
+}
+
+impl<T: Unsigned> ReifyTo<u8> for T {
+    fn reify() -> u8 {
+        <T as Unsigned>::to_u8()
+    }
+}
+
+impl<T: Unsigned> ReifyTo<u16> for T {
+    fn reify() -> u16 {
+        <T as Unsigned>::to_u16()
+    }
+}
+
+#[derive(Debug)]
+pub struct Bounded<T,L,U> {
+    pub val: T,
+    _lower_inclusive: PhantomData<L>,
+    _upper_inclusive: PhantomData<U>,
+}
+
+impl<T: PartialOrd, L: ReifyTo<T>, U: ReifyTo<T>> Bounded<T,L,U> {
+    pub fn clamp(val: T) -> Bounded<T,L,U> {
+        Bounded {
+            val: num::clamp(val, L::reify(), U::reify()),
+            _lower_inclusive: PhantomData,
+            _upper_inclusive: PhantomData
+        }
+    }
+}
+
+pub fn coerce<T, Lower1, Upper1, Lower2, Upper2>(b: Bounded<T, Lower1, Upper1>) -> Bounded<T, Lower2, Upper2>
+where
+    T: PartialOrd,
+    Lower1: ReifyTo<T>,
+    Upper1: ReifyTo<T>,
+    Lower2: ReifyTo<T>,
+    Upper2: ReifyTo<T>,
+
+    // Lower2 <= Upper2
+    Lower2 : Cmp<Upper2>,
+    Lower2: IsLessOrEqualPrivate<Upper2, <Lower2 as Cmp<Upper2>>::Output>,
+    <Lower2 as IsLessOrEqualPrivate<Upper2, <Lower2 as Cmp<Upper2>>::Output>>::Output : Same<B1>,
+
+    // Lower1 <= Lower2
+    Lower2 : Cmp<Lower1>,
+    Lower2: IsLessOrEqualPrivate<Lower1, <Lower2 as Cmp<Lower1>>::Output>,
+    <Lower2 as IsLessOrEqualPrivate<Lower1, <Lower2 as Cmp<Lower1>>::Output>>::Output : Same<B1>,
+
+    // Lower2 <= Upper1
+    Lower2 : Cmp<Upper1>,
+    Lower2: IsLessOrEqualPrivate<Upper1, <Lower2 as Cmp<Upper1>>::Output>,
+    <Lower2 as IsLessOrEqualPrivate<Upper1, <Lower2 as Cmp<Upper1>>::Output>>::Output : Same<B1>,
+
+    // Upper1 <= Upper2
+    Upper1 : Cmp<Upper2>,
+    Upper1: IsLessOrEqualPrivate<Upper2, <Upper1 as Cmp<Upper2>>::Output>,
+    <Upper1 as IsLessOrEqualPrivate<Upper2, <Upper1 as Cmp<Upper2>>::Output>>::Output : Same<B1>,
+{
+    Bounded {
+        val: b.val,
+        _lower_inclusive: PhantomData,
+        _upper_inclusive: PhantomData,
+    }
+}

--- a/src/vehicles/kial_niro.rs
+++ b/src/vehicles/kial_niro.rs
@@ -1,5 +1,12 @@
 #![allow(dead_code)]
 
+use ranges;
+use typenum::consts::*;
+type U1723 = op!{U1000 + U723};
+type U3358 = op!{U1000 + U1000 + U1000 + U358};
+type U3440 = op!{U1000 + U1000 + U1000 + U440};
+type U3446 = op!{U1000 + U1000 + U1000 + U446};
+
 /// Kia Niro
 
 // ********************************************************************
@@ -229,6 +236,8 @@ pub const STEERING_SPOOF_LOW_SIGNAL_RANGE_MIN: u16 = 656;
 //
 pub const STEERING_SPOOF_LOW_SIGNAL_RANGE_MAX: u16 = 3358;
 
+pub type SteeringSpoofLowSignal = ranges::Bounded<u16, U656, U3358>;
+
 /*
  * @brief Minimum allowed value for the low spoof signal value. [steps] */
 //
@@ -242,6 +251,8 @@ pub const STEERING_SPOOF_HIGH_SIGNAL_RANGE_MIN: u16 = 738;
 // Equal to \ref STEERING_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX * \ref STEPS_PER_VOLT.
 //
 pub const STEERING_SPOOF_HIGH_SIGNAL_RANGE_MAX: u16 = 3440;
+
+pub type SteeringSpoofHighSignal = ranges::Bounded<u16, U738, U3440>;
 
 /*
  * @brief Scalar value for the low spoof signal taken from a calibration
@@ -350,6 +361,8 @@ pub const THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MIN: u16 = 311;
 //
 pub const THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MAX: u16 = 1723;
 
+pub type ThrottleSpoofLowSignal = ranges::Bounded<u16, U311, U1723>;
+
 /*
  * @brief Minimum allowed value for the low spoof signal value. [steps] */
 //
@@ -363,6 +376,9 @@ pub const THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MIN: u16 = 620;
 // Equal to \ref THROTTLE_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX * \ref STEPS_PER_VOLT.
 //
 pub const THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MAX: u16 = 3446;
+
+pub type ThrottleSpoofHighSignal = ranges::Bounded<u16, U620, U3446>;
+
 
 /*
  * @brief Calculation to convert a throttle position to a low spoof voltage. */

--- a/src/vehicles/kial_soul_ev.rs
+++ b/src/vehicles/kial_soul_ev.rs
@@ -1,5 +1,12 @@
 #![allow(dead_code)]
 
+use ranges;
+use typenum::consts::*;
+type U1638 = op!{U1000 + U638};
+type U1875 = op!{U1000 + U875};
+type U3358 = op!{U1000 + U1000 + U1000 + U358};
+type U3440 = op!{U1000 + U1000 + U1000 + U440};
+
 /// Kia Soul EV
 
 // ********************************************************************
@@ -122,6 +129,8 @@ pub const BRAKE_SPOOF_LOW_SIGNAL_RANGE_MIN: u16 = 273;
 //
 pub const BRAKE_SPOOF_LOW_SIGNAL_RANGE_MAX: u16 = 917;
 
+pub type BrakeSpoofLowSignal = ranges::Bounded<u16, U273, U917>;
+
 /*
  * @brief Minimum allowed value for the low spoof signal value. [steps] */
 //
@@ -135,6 +144,9 @@ pub const BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MIN: u16 = 572;
 // Equal to \ref BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX * \ref STEPS_PER_VOLT.
 //
 pub const BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MAX: u16 = 1875;
+
+pub type BrakeSpoofHighSignal = ranges::Bounded<u16, U572, U1875>;
+
 
 /*
  * @brief Calculation to convert a brake position to a low spoof voltage. */
@@ -229,6 +241,8 @@ pub const STEERING_SPOOF_LOW_SIGNAL_RANGE_MIN: u16 = 656;
 //
 pub const STEERING_SPOOF_LOW_SIGNAL_RANGE_MAX: u16 = 3358;
 
+pub type SteeringSpoofLowSignal = ranges::Bounded<u16, U656, U3358>;
+
 /*
  * @brief Minimum allowed value for the low spoof signal value. [steps] */
 //
@@ -242,6 +256,8 @@ pub const STEERING_SPOOF_HIGH_SIGNAL_RANGE_MIN: u16 = 738;
 // Equal to \ref STEERING_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX * \ref STEPS_PER_VOLT.
 //
 pub const STEERING_SPOOF_HIGH_SIGNAL_RANGE_MAX: u16 = 3440;
+
+pub type SteeringSpoofHighSignal = ranges::Bounded<u16, U738, U3440>;
 
 /*
  * @brief Scalar value for the low spoof signal taken from a calibration
@@ -350,6 +366,8 @@ pub const THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MIN: u16 = 245;
 //
 pub const THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MAX: u16 = 1638;
 
+pub type ThrottleSpoofLowSignal = ranges::Bounded<u16, U245, U1638>;
+
 /*
  * @brief Minimum allowed value for the low spoof signal value. [steps] */
 //
@@ -364,6 +382,7 @@ pub const THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MIN: u16 = 573;
 //
 pub const THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MAX: u16 = 3358;
 
+pub type ThrottleSpoofHighSignal = ranges::Bounded<u16, U573, U3358>;
 /*
  * @brief Calculation to convert a throttle position to a low spoof voltage. */
 //

--- a/src/vehicles/kial_soul_petrol.rs
+++ b/src/vehicles/kial_soul_petrol.rs
@@ -1,5 +1,12 @@
 #![allow(dead_code)]
 
+use ranges;
+use typenum::consts::*;
+type U1638 = op!{U1000 + U638};
+type U1875 = op!{U1000 + U875};
+type U3358 = op!{U1000 + U1000 + U1000 + U358};
+type U3440 = op!{U1000 + U1000 + U1000 + U440};
+
 /// Kia Soul Petrol
 
 // ********************************************************************
@@ -291,6 +298,8 @@ pub const STEERING_SPOOF_LOW_SIGNAL_RANGE_MIN: u16 = 656;
 //
 pub const STEERING_SPOOF_LOW_SIGNAL_RANGE_MAX: u16 = 3358;
 
+pub type SteeringSpoofLowSignal = ranges::Bounded<u16, U656, U3358>;
+
 /*
  * @brief Minimum allowed value for the low spoof signal value. [steps] */
 //
@@ -304,6 +313,8 @@ pub const STEERING_SPOOF_HIGH_SIGNAL_RANGE_MIN: u16 = 738;
 // Equal to \ref STEERING_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX * \ref STEPS_PER_VOLT.
 //
 pub const STEERING_SPOOF_HIGH_SIGNAL_RANGE_MAX: u16 = 3440;
+
+pub type SteeringSpoofHighSignal = ranges::Bounded<u16, U738, U3440>;
 
 /*
  * @brief Scalar value for the low spoof signal taken from a calibration
@@ -412,6 +423,8 @@ pub const THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MIN: u16 = 245;
 //
 pub const THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MAX: u16 = 1638;
 
+pub type ThrottleSpoofLowSignal = ranges::Bounded<u16, U245, U1638>;
+
 /*
  * @brief Minimum allowed value for the low spoof signal value. [steps] */
 //
@@ -425,6 +438,8 @@ pub const THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MIN: u16 = 573;
 // Equal to \ref THROTTLE_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX * \ref STEPS_PER_VOLT.
 //
 pub const THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MAX: u16 = 3358;
+
+pub type ThrottleSpoofHighSignal = ranges::Bounded<u16, U573, U3358>;
 
 /*
  * @brief Calculation to convert a throttle position to a low spoof voltage. */


### PR DESCRIPTION
- Add the generic ranges::Bounded wrapper type, built upon typenum
- Replace u16 parameters to the dac module with Bounded<u16, 0, 4095>,
  effectively a compile time check that the appropriate range checks or clamping
  has been done
- Implement Bounded-based clamping at all call sites