### PR TITLE
Add preliminary error paths, minor fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "stm32f767-hal"
 version = "0.0.1"
-source = "git+https://github.com/jonlamb-gh/stm32f767-hal.git?branch=devel#eb667d5ef38cc0eb0a307bff35cb8c32fb2ec5b6"
+source = "git+https://github.com/jonlamb-gh/stm32f767-hal.git?branch=devel#6a907048987ade3816ef535f5a9c38ad03cc0e83"
 dependencies = [
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortex-m 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "stm32f767-hal"
 version = "0.0.1"
-source = "git+https://github.com/jonlamb-gh/stm32f767-hal.git?branch=devel#6a907048987ade3816ef535f5a9c38ad03cc0e83"
+source = "git+https://github.com/jonlamb-gh/stm32f767-hal.git?branch=devel#3806af4aed6cc453dc593522ae7c4537ace66c57"
 dependencies = [
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortex-m 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/brake/kia_soul_ev_niro/brake_module.rs
+++ b/src/brake/kia_soul_ev_niro/brake_module.rs
@@ -15,6 +15,7 @@ use nucleo_f767zi::hal::can::CanFrame;
 use nucleo_f767zi::hal::prelude::*;
 use num;
 use oscc_magic_byte::*;
+use oxcc_error::OxccError;
 use ranges;
 use vehicle::*;
 
@@ -84,38 +85,55 @@ impl UnpreparedBrakeModule {
 }
 
 impl BrakeModule {
-    fn disable_control(&mut self, debug_console: &mut DebugConsole) {
+    pub fn disable_control(&mut self, debug_console: &mut DebugConsole) -> Result<(), OxccError> {
+        let mut result = Ok(());
+
         if self.control_state.enabled {
             self.brake_pedal_position.prevent_signal_discontinuity();
 
-            self.brake_dac.output_ab(
+            if let Err(_) = self.brake_dac.output_ab(
                 DacOutput::clamp(self.brake_pedal_position.low()),
                 DacOutput::clamp(self.brake_pedal_position.high()),
-            );
+            ) {
+                result = Err(OxccError::IO);
+            }
 
+            // even if we've encountered an error, we can still disable
             self.brake_pins.spoof_enable.set_low();
             self.brake_pins.brake_light_enable.set_low();
             self.control_state.enabled = false;
             writeln!(debug_console, "Brake control disabled");
         }
+
+        result
     }
 
-    fn enable_control(&mut self, debug_console: &mut DebugConsole) {
+    fn enable_control(&mut self, debug_console: &mut DebugConsole) -> Result<(), OxccError> {
+        let mut result = Ok(());
+
         if !self.control_state.enabled && !self.control_state.operator_override {
             self.brake_pedal_position.prevent_signal_discontinuity();
 
-            self.brake_dac.output_ab(
+            if let Err(_) = self.brake_dac.output_ab(
                 DacOutput::clamp(self.brake_pedal_position.low()),
                 DacOutput::clamp(self.brake_pedal_position.high()),
-            );
-
-            self.brake_pins.spoof_enable.set_high();
-            self.control_state.enabled = true;
-            writeln!(debug_console, "Brake control enabled");
+            ) {
+                result = Err(OxccError::IO);
+            } else {
+                self.brake_pins.spoof_enable.set_high();
+                self.control_state.enabled = true;
+                writeln!(debug_console, "Brake control enabled");
+            }
         }
+
+        result
     }
 
-    fn update_brake(&mut self, spoof_command_high: u16, spoof_command_low: u16) {
+    fn update_brake(
+        &mut self,
+        spoof_command_high: u16,
+        spoof_command_low: u16,
+    ) -> Result<(), OxccError> {
         if self.control_state.enabled {
             let spoof_high = BrakeSpoofHighSignal::clamp(spoof_command_high);
             let spoof_low = BrakeSpoofLowSignal::clamp(spoof_command_low);
@@ -130,20 +148,22 @@ impl BrakeModule {
 
             // TODO - revisit this, enforce high->A, low->B
             self.brake_dac
-                .output_ab(ranges::coerce(spoof_high), ranges::coerce(spoof_low));
+                .output_ab(ranges::coerce(spoof_high), ranges::coerce(spoof_low))?;
         }
+
+        Ok(())
     }
 
     pub fn check_for_faults(
         &mut self,
         timer_ms: &MsTimer,
         debug_console: &mut DebugConsole,
-    ) -> Option<&OsccFaultReport> {
+    ) -> Result<Option<&OsccFaultReport>, OxccError> {
         if !self.control_state.enabled && !self.control_state.dtcs.are_any_set() {
             // Assumes this module already went through the proper transition into a faulted
             // and disabled state, and we do not want to double-report a possible duplicate
             // fault.
-            return None;
+            return Ok(None);
         }
 
         self.brake_pedal_position.update();
@@ -164,7 +184,7 @@ impl BrakeModule {
 
         // sensor pins tied to ground - a value of zero indicates disconnection
         if inputs_grounded {
-            self.disable_control(debug_console);
+            self.disable_control(debug_console)?;
 
             self.control_state
                 .dtcs
@@ -177,9 +197,9 @@ impl BrakeModule {
                 "Bad value read from brake pedal position sensor"
             );
 
-            Some(&self.fault_report)
+            Ok(Some(&self.fault_report))
         } else if operator_overridden && !self.control_state.operator_override {
-            self.disable_control(debug_console);
+            self.disable_control(debug_console)?;
 
             self.control_state
                 .dtcs
@@ -191,11 +211,11 @@ impl BrakeModule {
 
             writeln!(debug_console, "Brake operator override");
 
-            Some(&self.fault_report)
+            Ok(Some(&self.fault_report))
         } else {
             self.control_state.dtcs.clear_all();
             self.control_state.operator_override = false;
-            None
+            Ok(None)
         }
     }
 
@@ -210,41 +230,46 @@ impl BrakeModule {
         &self.brake_report
     }
 
-    // TODO - error handling
-    pub fn process_rx_frame(&mut self, can_frame: &CanFrame, debug_console: &mut DebugConsole) {
+    pub fn process_rx_frame(
+        &mut self,
+        can_frame: &CanFrame,
+        debug_console: &mut DebugConsole,
+    ) -> Result<(), OxccError> {
         if let CanFrame::DataFrame(ref frame) = can_frame {
             let id: u32 = frame.id().into();
             let data = frame.data();
 
             if (data[0] == OSCC_MAGIC_BYTE_0) && (data[1] == OSCC_MAGIC_BYTE_1) {
                 if id == OSCC_BRAKE_ENABLE_CAN_ID.into() {
-                    self.enable_control(debug_console);
+                    self.enable_control(debug_console)?;
                 } else if id == OSCC_BRAKE_DISABLE_CAN_ID.into() {
-                    self.disable_control(debug_console);
+                    self.disable_control(debug_console)?;
                 } else if id == OSCC_BRAKE_COMMAND_CAN_ID.into() {
-                    self.process_brake_command(&OsccBrakeCommand::from(frame));
+                    self.process_brake_command(&OsccBrakeCommand::from(frame))?;
                 } else if id == OSCC_FAULT_REPORT_CAN_ID.into() {
-                    self.process_fault_report(&OsccFaultReport::from(frame), debug_console);
+                    self.process_fault_report(&OsccFaultReport::from(frame), debug_console)?;
                 }
             }
         }
+
+        Ok(())
     }
 
     fn process_fault_report(
         &mut self,
         fault_report: &OsccFaultReport,
         debug_console: &mut DebugConsole,
-    ) {
-        self.disable_control(debug_console);
-
+    ) -> Result<(), OxccError> {
         writeln!(
             debug_console,
             "Fault report received from: {} DTCs: {}",
             fault_report.fault_origin_id, fault_report.dtcs
         );
+
+        self.disable_control(debug_console)
     }
 
-    fn process_brake_command(&mut self, command: &OsccBrakeCommand) {
+    fn process_brake_command(&mut self, command: &OsccBrakeCommand) -> Result<(), OxccError> {
         let clamped_position = num::clamp(
             command.pedal_command,
             MINIMUM_BRAKE_COMMAND,
@@ -266,7 +291,7 @@ impl BrakeModule {
         let spoof_value_low = (STEPS_PER_VOLT * spoof_voltage_low) as u16;
         let spoof_value_high = (STEPS_PER_VOLT * spoof_voltage_high) as u16;
 
-        self.update_brake(spoof_value_high, spoof_value_low);
+        self.update_brake(spoof_value_high, spoof_value_low)
     }
 }
 

--- a/src/brake/kia_soul_ev_niro/brake_module.rs
+++ b/src/brake/kia_soul_ev_niro/brake_module.rs
@@ -86,47 +86,50 @@ impl UnpreparedBrakeModule {
 
 impl BrakeModule {
     pub fn disable_control(&mut self, debug_console: &mut DebugConsole) -> Result<(), OxccError> {
-        let mut result = Ok(());
-
         if self.control_state.enabled {
             self.brake_pedal_position.prevent_signal_discontinuity();
 
-            if let Err(_) = self.brake_dac.output_ab(
+            let result = self.brake_dac.output_ab(
                 DacOutput::clamp(self.brake_pedal_position.low()),
                 DacOutput::clamp(self.brake_pedal_position.high()),
-            ) {
-                result = Err(OxccError::IO);
-            }
+            );
 
             // even if we've encountered an error, we can still disable
             self.brake_pins.spoof_enable.set_low();
             self.brake_pins.brake_light_enable.set_low();
             self.control_state.enabled = false;
             writeln!(debug_console, "Brake control disabled");
+
+            return if let Err(e) = result {
+                Err(OxccError::from(e))
+            } else {
+                Ok(())
+            };
         }
 
-        result
+        Ok(())
     }
 
     fn enable_control(&mut self, debug_console: &mut DebugConsole) -> Result<(), OxccError> {
-        let mut result = Ok(());
-
         if !self.control_state.enabled && !self.control_state.operator_override {
             self.brake_pedal_position.prevent_signal_discontinuity();
 
-            if let Err(_) = self.brake_dac.output_ab(
+            let result = self.brake_dac.output_ab(
                 DacOutput::clamp(self.brake_pedal_position.low()),
                 DacOutput::clamp(self.brake_pedal_position.high()),
-            ) {
-                result = Err(OxccError::IO);
+            );
+
+            return if let Err(e) = result {
+                Err(OxccError::from(e))
             } else {
                 self.brake_pins.spoof_enable.set_high();
                 self.control_state.enabled = true;
                 writeln!(debug_console, "Brake control enabled");
-            }
+                Ok(())
+            };
         }
 
-        result
+        Ok(())
     }
 
     fn update_brake(

--- a/src/can_gateway_module.rs
+++ b/src/can_gateway_module.rs
@@ -37,6 +37,7 @@ impl CanGatewayModule {
             steering_report_can_frame: default_steering_report_data_frame(),
         }
     }
+
     pub fn republish_obd_frames_to_control_can_bus(&mut self) -> Result<(), OxccError> {
         // poll both OBD CAN FIFOs
         for fifo in &[RxFifo::Fifo0, RxFifo::Fifo1] {
@@ -53,14 +54,10 @@ impl CanGatewayModule {
         frame: &CanFrame,
     ) -> Result<(), OxccError> {
         let id: u32 = frame.id().into();
-        let mut is_a_match = false;
 
-        if (id == KIA_SOUL_OBD_STEERING_WHEEL_ANGLE_CAN_ID.into())
+        let mut is_a_match = (id == KIA_SOUL_OBD_STEERING_WHEEL_ANGLE_CAN_ID.into())
             || (id == KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID.into())
-            || (id == KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID.into())
-        {
-            is_a_match = true;
-        }
+            || (id == KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID.into());
 
         #[cfg(feature = "kia-soul-ev")]
         {

--- a/src/fault_condition.rs
+++ b/src/fault_condition.rs
@@ -44,6 +44,8 @@ impl FaultCondition {
                 self.condition_start_time = now;
             }
 
+            // TODO - need to fix this ported logic
+            // panicked at 'attempt to subtract with overflow', src/fault_condition.rs:47:28
             let duration = now - self.condition_start_time;
 
             if duration >= max_duration {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,10 +25,11 @@ mod dtc;
 mod dual_signal;
 mod fault_condition;
 mod ms_timer;
+mod oxcc_error;
+mod ranges;
 mod steering_module;
 mod throttle_module;
 mod types;
-mod ranges;
 
 #[path = "can_protocols/brake_can_protocol.rs"]
 mod brake_can_protocol;
@@ -61,19 +62,29 @@ mod brake_module;
 
 use board::{hard_fault_indicator, FullBoard};
 use brake_can_protocol::BrakeReportPublisher;
-use brake_module::UnpreparedBrakeModule;
+use brake_module::{BrakeModule, UnpreparedBrakeModule};
 use can_gateway_module::CanGatewayModule;
 use core::fmt::Write;
 use fault_can_protocol::FaultReportPublisher;
+use ms_timer::MsTimer;
+use nucleo_f767zi::debug_console::DebugConsole;
+use nucleo_f767zi::hal::can::CanError;
 use nucleo_f767zi::hal::can::RxFifo;
-use nucleo_f767zi::led;
+use nucleo_f767zi::led::{Color, Leds};
+use oxcc_error::OxccError;
 use rt::ExceptionFrame;
 use steering_can_protocol::SteeringReportPublisher;
-use steering_module::UnpreparedSteeringModule;
+use steering_module::{SteeringModule, UnpreparedSteeringModule};
 use throttle_can_protocol::ThrottleReportPublisher;
-use throttle_module::UnpreparedThrottleModule;
+use throttle_module::{ThrottleModule, UnpreparedThrottleModule};
 
 const DEBUG_WRITE_FAILURE: &str = "Failed to write to debug_console";
+
+struct ControlModules {
+    pub brake: BrakeModule,
+    pub throttle: ThrottleModule,
+    pub steering: SteeringModule,
+}
 
 entry!(main);
 
@@ -99,13 +110,14 @@ fn main() -> ! {
     ) = FullBoard::new().split_components();
 
     // turn on the blue LED
-    board.leds[led::Color::Blue].on();
+    board.leds[Color::Blue].on();
 
     // show startup message and reset warnings if debugging
     #[cfg(debug_assertions)]
     {
-        writeln!(debug_console, "oxcc is running").unwrap();
+        writeln!(debug_console, "OxCC is running").unwrap();
 
+        // TODO - some of these are worthy of disabling controls?
         if board.reset_conditions.low_power {
             writeln!(debug_console, "WARNING: low-power reset detected")
                 .expect(DEBUG_WRITE_FAILURE);
@@ -135,61 +147,80 @@ fn main() -> ! {
         UnpreparedSteeringModule::new(torque_sensor, steering_dac, steering_pins);
     let mut can_gateway = CanGatewayModule::new(can_publish_timer, control_can, obd_can);
 
-    let mut brake = unprepared_brake_module.prepare_module();
-    let mut throttle = unprepared_throttle_module.prepare_module();
-    let mut steering = unprepared_steering_module.prepare_module();
+    let mut modules = ControlModules {
+        brake: unprepared_brake_module.prepare_module(),
+        throttle: unprepared_throttle_module.prepare_module(),
+        steering: unprepared_steering_module.prepare_module(),
+    };
 
     // send reports immediately
-    // TODO - high-level publish error handling
-    let _ = can_gateway.publish_brake_report(brake.supply_brake_report());
-
-    let _ = can_gateway.publish_throttle_report(throttle.supply_throttle_report());
-
-    let _ = can_gateway.publish_steering_report(steering.supply_steering_report());
+    if let Err(e) = publish_reports(&mut modules, &mut can_gateway) {
+        handle_error(
+            e,
+            &mut modules,
+            &mut can_gateway,
+            &mut debug_console,
+            &mut board.leds,
+        );
+    }
 
     loop {
         // refresh the independent watchdog
         board.wdg.refresh();
 
-        // poll both control CAN FIFOs
-        for fifo in &[RxFifo::Fifo0, RxFifo::Fifo1] {
-            match can_gateway.control_can().receive(fifo) {
-                Ok(rx_frame) => {
-                    brake.process_rx_frame(&rx_frame, &mut debug_console);
-                    throttle.process_rx_frame(&rx_frame, &mut debug_console);
-                    steering.process_rx_frame(&rx_frame, &mut debug_console);
-                }
-                // TODO - CAN receive error handling
-                // includes BufferExhausted, which means no data available
-                Err(_) => {} /*Err(e) => writeln!(debug_console, "CAN receive failure: {:?}", e)
-                              *    .expect(DEBUG_WRITE_FAILURE), // TODO - CAN receive error
-                              * handling */
-            }
+        // check the control CAN FIFOs for any frames to be processed
+        if let Err(e) =
+            check_and_process_control_can_frames(&mut modules, &mut can_gateway, &mut debug_console)
+        {
+            handle_error(
+                e,
+                &mut modules,
+                &mut can_gateway,
+                &mut debug_console,
+                &mut board.leds,
+            );
         }
 
-        // TODO - high-level publish error handling
-        if let Some(brake_fault) = brake.check_for_faults(&timer_ms, &mut debug_console) {
-            let _ = can_gateway.publish_fault_report(brake_fault);
-        }
-        if let Some(throttle_fault) = throttle.check_for_faults(&timer_ms, &mut debug_console) {
-            let _ = can_gateway.publish_fault_report(throttle_fault);
-        }
-        if let Some(steering_fault) = steering.check_for_faults(&timer_ms, &mut debug_console) {
-            let _ = can_gateway.publish_fault_report(steering_fault);
+        // check modules for fault conditions, sending reports as needed
+        if let Err(e) = check_for_faults(
+            &mut modules,
+            &mut can_gateway,
+            &timer_ms,
+            &mut debug_console,
+        ) {
+            handle_error(
+                e,
+                &mut modules,
+                &mut can_gateway,
+                &mut debug_console,
+                &mut board.leds,
+            );
         }
 
-        can_gateway.republish_obd_frames_to_control_can_bus();
+        // republish OBD frames to control CAN bus
+        if let Err(e) = can_gateway.republish_obd_frames_to_control_can_bus() {
+            handle_error(
+                e,
+                &mut modules,
+                &mut can_gateway,
+                &mut debug_console,
+                &mut board.leds,
+            );
+        }
 
         // periodically publish all report frames
         if can_gateway.wait_for_publish() {
-            board.leds[led::Color::Green].toggle();
+            board.leds[Color::Green].toggle();
 
-            // TODO - high-level publish error handling
-            let _ = can_gateway.publish_brake_report(brake.supply_brake_report());
-
-            let _ = can_gateway.publish_throttle_report(throttle.supply_throttle_report());
-
-            let _ = can_gateway.publish_steering_report(steering.supply_steering_report());
+            if let Err(e) = publish_reports(&mut modules, &mut can_gateway) {
+                handle_error(
+                    e,
+                    &mut modules,
+                    &mut can_gateway,
+                    &mut debug_console,
+                    &mut board.leds,
+                );
+            }
         }
 
         // TODO - do anything with the user button?
@@ -198,6 +229,112 @@ fn main() -> ! {
             #[cfg(feature = "panic-over-semihosting")]
             cortex_m::asm::bkpt();
         }
+    }
+}
+
+fn check_and_process_control_can_frames(
+    modules: &mut ControlModules,
+    can_gateway: &mut CanGatewayModule,
+    debug_console: &mut DebugConsole,
+) -> Result<(), OxccError> {
+    // poll both control CAN FIFOs
+    for fifo in &[RxFifo::Fifo0, RxFifo::Fifo1] {
+        match can_gateway.control_can().receive(fifo) {
+            Ok(rx_frame) => {
+                modules.brake.process_rx_frame(&rx_frame, debug_console)?;
+                modules
+                    .throttle
+                    .process_rx_frame(&rx_frame, debug_console)?;
+                modules
+                    .steering
+                    .process_rx_frame(&rx_frame, debug_console)?;
+            }
+            Err(e) => {
+                // report all but BufferExhausted (no data)
+                if e != CanError::BufferExhausted {
+                    return Err(OxccError::from(e));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn check_for_faults(
+    modules: &mut ControlModules,
+    can_gateway: &mut CanGatewayModule,
+    timer_ms: &MsTimer,
+    debug_console: &mut DebugConsole,
+) -> Result<(), OxccError> {
+    let maybe_fault = modules.brake.check_for_faults(timer_ms, debug_console)?;
+    if let Some(brake_fault) = maybe_fault {
+        can_gateway.publish_fault_report(brake_fault)?;
+    }
+
+    let maybe_fault = modules.throttle.check_for_faults(timer_ms, debug_console)?;
+    if let Some(throttle_fault) = maybe_fault {
+        can_gateway.publish_fault_report(throttle_fault)?;
+    }
+
+    let maybe_fault = modules.steering.check_for_faults(timer_ms, debug_console)?;
+    if let Some(steering_fault) = maybe_fault {
+        can_gateway.publish_fault_report(steering_fault)?;
+    }
+
+    Ok(())
+}
+
+fn publish_reports(
+    modules: &mut ControlModules,
+    can_gateway: &mut CanGatewayModule,
+) -> Result<(), OxccError> {
+    // attempt to publish them all, only report the first to fail
+    let mut result = Ok(());
+
+    if let Err(e) = can_gateway.publish_brake_report(modules.brake.supply_brake_report()) {
+        result = Err(OxccError::from(e));
+    }
+
+    if let Err(e) = can_gateway.publish_throttle_report(modules.throttle.supply_throttle_report()) {
+        result = Err(OxccError::from(e));
+    }
+
+    if let Err(e) = can_gateway.publish_steering_report(modules.steering.supply_steering_report()) {
+        result = Err(OxccError::from(e));
+    }
+
+    result
+}
+
+// TODO - this is just an example for now
+fn handle_error(
+    error: OxccError,
+    modules: &mut ControlModules,
+    can_gateway: &mut CanGatewayModule,
+    debug_console: &mut DebugConsole,
+    leds: &mut Leds,
+) {
+    let mut ignore_error: bool = false;
+
+    // it is typically to get timeout errors if the CAN bus is not active or
+    // there are no other nodes connected to it
+    if error == OxccError::CanBusTxTimeout {
+        ignore_error = true;
+    }
+
+    if !ignore_error {
+        leds[Color::Red].on();
+
+        writeln!(debug_console, "ERROR: {:#?}", error).expect(DEBUG_WRITE_FAILURE);
+
+        // disable all controls
+        let _ = modules.throttle.disable_control(debug_console);
+        let _ = modules.steering.disable_control(debug_console);
+        let _ = modules.brake.disable_control(debug_console);
+
+        // publish reports
+        let _ = publish_reports(modules, can_gateway);
     }
 }
 

--- a/src/oxcc_error.rs
+++ b/src/oxcc_error.rs
@@ -1,0 +1,27 @@
+// might make more sense to just use the existing HAL errors?
+
+use nucleo_f767zi::hal::can::CanError;
+use nucleo_f767zi::hal::spi;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum OxccError {
+    IO,
+    CanBusTxTimeout,
+}
+
+impl From<spi::Error> for OxccError {
+    fn from(e: spi::Error) -> OxccError {
+        match e {
+            _ => OxccError::IO,
+        }
+    }
+}
+
+impl From<CanError> for OxccError {
+    fn from(e: CanError) -> OxccError {
+        match e {
+            CanError::Timeout => OxccError::CanBusTxTimeout,
+            _ => OxccError::IO,
+        }
+    }
+}

--- a/src/oxcc_error.rs
+++ b/src/oxcc_error.rs
@@ -5,23 +5,18 @@ use nucleo_f767zi::hal::spi;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum OxccError {
-    IO,
-    CanBusTxTimeout,
+    Spi(spi::Error),
+    Can(CanError),
 }
 
 impl From<spi::Error> for OxccError {
-    fn from(e: spi::Error) -> OxccError {
-        match e {
-            _ => OxccError::IO,
-        }
+    fn from(e: spi::Error) -> Self {
+        OxccError::Spi(e)
     }
 }
 
 impl From<CanError> for OxccError {
-    fn from(e: CanError) -> OxccError {
-        match e {
-            CanError::Timeout => OxccError::CanBusTxTimeout,
-            _ => OxccError::IO,
-        }
+    fn from(e: CanError) -> Self {
+        OxccError::Can(e)
     }
 }

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use num;
 
-use typenum::{Unsigned, Cmp, B1, Same};
+use typenum::{Cmp, Same, Unsigned, B1};
 // Although this says private, it's needed to write generic inequality
 // constraints for typenums
 use typenum::private::IsLessOrEqualPrivate;
@@ -25,18 +25,18 @@ impl<T: Unsigned> ReifyTo<u16> for T {
 }
 
 #[derive(Debug)]
-pub struct Bounded<T,L,U> {
+pub struct Bounded<T, L, U> {
     val: T,
     _lower_inclusive: PhantomData<L>,
     _upper_inclusive: PhantomData<U>,
 }
 
-impl<T: PartialOrd, L: ReifyTo<T>, U: ReifyTo<T>> Bounded<T,L,U> {
-    pub fn clamp(val: T) -> Bounded<T,L,U> {
+impl<T: PartialOrd, L: ReifyTo<T>, U: ReifyTo<T>> Bounded<T, L, U> {
+    pub fn clamp(val: T) -> Bounded<T, L, U> {
         Bounded {
             val: num::clamp(val, L::reify(), U::reify()),
             _lower_inclusive: PhantomData,
-            _upper_inclusive: PhantomData
+            _upper_inclusive: PhantomData,
         }
     }
 
@@ -45,7 +45,9 @@ impl<T: PartialOrd, L: ReifyTo<T>, U: ReifyTo<T>> Bounded<T,L,U> {
     }
 }
 
-pub fn coerce<T, Lower1, Upper1, Lower2, Upper2>(b: Bounded<T, Lower1, Upper1>) -> Bounded<T, Lower2, Upper2>
+pub fn coerce<T, Lower1, Upper1, Lower2, Upper2>(
+    b: Bounded<T, Lower1, Upper1>,
+) -> Bounded<T, Lower2, Upper2>
 where
     T: PartialOrd,
     Lower1: ReifyTo<T>,
@@ -54,24 +56,24 @@ where
     Upper2: ReifyTo<T>,
 
     // Lower2 <= Upper2
-    Lower2 : Cmp<Upper2>,
+    Lower2: Cmp<Upper2>,
     Lower2: IsLessOrEqualPrivate<Upper2, <Lower2 as Cmp<Upper2>>::Output>,
-    <Lower2 as IsLessOrEqualPrivate<Upper2, <Lower2 as Cmp<Upper2>>::Output>>::Output : Same<B1>,
+    <Lower2 as IsLessOrEqualPrivate<Upper2, <Lower2 as Cmp<Upper2>>::Output>>::Output: Same<B1>,
 
     // Lower1 <= Lower2
-    Lower2 : Cmp<Lower1>,
+    Lower2: Cmp<Lower1>,
     Lower2: IsLessOrEqualPrivate<Lower1, <Lower2 as Cmp<Lower1>>::Output>,
-    <Lower2 as IsLessOrEqualPrivate<Lower1, <Lower2 as Cmp<Lower1>>::Output>>::Output : Same<B1>,
+    <Lower2 as IsLessOrEqualPrivate<Lower1, <Lower2 as Cmp<Lower1>>::Output>>::Output: Same<B1>,
 
     // Lower2 <= Upper1
-    Lower2 : Cmp<Upper1>,
+    Lower2: Cmp<Upper1>,
     Lower2: IsLessOrEqualPrivate<Upper1, <Lower2 as Cmp<Upper1>>::Output>,
-    <Lower2 as IsLessOrEqualPrivate<Upper1, <Lower2 as Cmp<Upper1>>::Output>>::Output : Same<B1>,
+    <Lower2 as IsLessOrEqualPrivate<Upper1, <Lower2 as Cmp<Upper1>>::Output>>::Output: Same<B1>,
 
     // Upper1 <= Upper2
-    Upper1 : Cmp<Upper2>,
+    Upper1: Cmp<Upper2>,
     Upper1: IsLessOrEqualPrivate<Upper2, <Upper1 as Cmp<Upper2>>::Output>,
-    <Upper1 as IsLessOrEqualPrivate<Upper2, <Upper1 as Cmp<Upper2>>::Output>>::Output : Same<B1>,
+    <Upper1 as IsLessOrEqualPrivate<Upper2, <Upper1 as Cmp<Upper2>>::Output>>::Output: Same<B1>,
 {
     Bounded {
         val: b.val,

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use num;
 
-use typenum::{Cmp, Same, Unsigned, B1};
+use typenum::{Unsigned, Cmp, B1, Same};
 // Although this says private, it's needed to write generic inequality
 // constraints for typenums
 use typenum::private::IsLessOrEqualPrivate;
@@ -25,18 +25,18 @@ impl<T: Unsigned> ReifyTo<u16> for T {
 }
 
 #[derive(Debug)]
-pub struct Bounded<T, L, U> {
+pub struct Bounded<T,L,U> {
     val: T,
     _lower_inclusive: PhantomData<L>,
     _upper_inclusive: PhantomData<U>,
 }
 
-impl<T: PartialOrd, L: ReifyTo<T>, U: ReifyTo<T>> Bounded<T, L, U> {
-    pub fn clamp(val: T) -> Bounded<T, L, U> {
+impl<T: PartialOrd, L: ReifyTo<T>, U: ReifyTo<T>> Bounded<T,L,U> {
+    pub fn clamp(val: T) -> Bounded<T,L,U> {
         Bounded {
             val: num::clamp(val, L::reify(), U::reify()),
             _lower_inclusive: PhantomData,
-            _upper_inclusive: PhantomData,
+            _upper_inclusive: PhantomData
         }
     }
 
@@ -45,9 +45,7 @@ impl<T: PartialOrd, L: ReifyTo<T>, U: ReifyTo<T>> Bounded<T, L, U> {
     }
 }
 
-pub fn coerce<T, Lower1, Upper1, Lower2, Upper2>(
-    b: Bounded<T, Lower1, Upper1>,
-) -> Bounded<T, Lower2, Upper2>
+pub fn coerce<T, Lower1, Upper1, Lower2, Upper2>(b: Bounded<T, Lower1, Upper1>) -> Bounded<T, Lower2, Upper2>
 where
     T: PartialOrd,
     Lower1: ReifyTo<T>,
@@ -56,24 +54,24 @@ where
     Upper2: ReifyTo<T>,
 
     // Lower2 <= Upper2
-    Lower2: Cmp<Upper2>,
+    Lower2 : Cmp<Upper2>,
     Lower2: IsLessOrEqualPrivate<Upper2, <Lower2 as Cmp<Upper2>>::Output>,
-    <Lower2 as IsLessOrEqualPrivate<Upper2, <Lower2 as Cmp<Upper2>>::Output>>::Output: Same<B1>,
+    <Lower2 as IsLessOrEqualPrivate<Upper2, <Lower2 as Cmp<Upper2>>::Output>>::Output : Same<B1>,
 
     // Lower1 <= Lower2
-    Lower2: Cmp<Lower1>,
+    Lower2 : Cmp<Lower1>,
     Lower2: IsLessOrEqualPrivate<Lower1, <Lower2 as Cmp<Lower1>>::Output>,
-    <Lower2 as IsLessOrEqualPrivate<Lower1, <Lower2 as Cmp<Lower1>>::Output>>::Output: Same<B1>,
+    <Lower2 as IsLessOrEqualPrivate<Lower1, <Lower2 as Cmp<Lower1>>::Output>>::Output : Same<B1>,
 
     // Lower2 <= Upper1
-    Lower2: Cmp<Upper1>,
+    Lower2 : Cmp<Upper1>,
     Lower2: IsLessOrEqualPrivate<Upper1, <Lower2 as Cmp<Upper1>>::Output>,
-    <Lower2 as IsLessOrEqualPrivate<Upper1, <Lower2 as Cmp<Upper1>>::Output>>::Output: Same<B1>,
+    <Lower2 as IsLessOrEqualPrivate<Upper1, <Lower2 as Cmp<Upper1>>::Output>>::Output : Same<B1>,
 
     // Upper1 <= Upper2
-    Upper1: Cmp<Upper2>,
+    Upper1 : Cmp<Upper2>,
     Upper1: IsLessOrEqualPrivate<Upper2, <Upper1 as Cmp<Upper2>>::Output>,
-    <Upper1 as IsLessOrEqualPrivate<Upper2, <Upper1 as Cmp<Upper2>>::Output>>::Output: Same<B1>,
+    <Upper1 as IsLessOrEqualPrivate<Upper2, <Upper1 as Cmp<Upper2>>::Output>>::Output : Same<B1>,
 {
     Bounded {
         val: b.val,

--- a/src/steering_module.rs
+++ b/src/steering_module.rs
@@ -13,6 +13,7 @@ use nucleo_f767zi::hal::can::CanFrame;
 use nucleo_f767zi::hal::prelude::*;
 use num;
 use oscc_magic_byte::*;
+use oxcc_error::OxccError;
 use ranges;
 use steering_can_protocol::*;
 use types::*;
@@ -85,56 +86,75 @@ impl UnpreparedSteeringModule {
 }
 
 impl SteeringModule {
-    pub fn disable_control(&mut self, debug_console: &mut DebugConsole) {
+    pub fn disable_control(&mut self, debug_console: &mut DebugConsole) -> Result<(), OxccError> {
+        let mut result = Ok(());
+
         if self.control_state.enabled {
             self.steering_torque.prevent_signal_discontinuity();
 
-            self.steering_dac.output_ab(
+            if let Err(_) = self.steering_dac.output_ab(
                 DacOutput::clamp(self.steering_torque.low()),
                 DacOutput::clamp(self.steering_torque.high()),
-            );
+            ) {
+                result = Err(OxccError::IO);
+            }
 
+            // even if we've encountered an error, we can still disable
             self.steering_pins.spoof_enable.set_low();
             self.control_state.enabled = false;
             writeln!(debug_console, "Steering control disabled");
         }
+
+        result
     }
 
-    pub fn enable_control(&mut self, debug_console: &mut DebugConsole) {
+    pub fn enable_control(&mut self, debug_console: &mut DebugConsole) -> Result<(), OxccError> {
+        let mut result = Ok(());
+
         if !self.control_state.enabled && !self.control_state.operator_override {
             self.steering_torque.prevent_signal_discontinuity();
 
-            self.steering_dac.output_ab(
+            if let Err(_) = self.steering_dac.output_ab(
                 DacOutput::clamp(self.steering_torque.low()),
                 DacOutput::clamp(self.steering_torque.high()),
-            );
-
-            self.steering_pins.spoof_enable.set_high();
-            self.control_state.enabled = true;
-            writeln!(debug_console, "Steering control enabled");
+            ) {
+                result = Err(OxccError::IO);
+            } else {
+                self.steering_pins.spoof_enable.set_high();
+                self.control_state.enabled = true;
+                writeln!(debug_console, "Steering control enabled");
+            }
         }
+
+        result
     }
 
-    pub fn update_steering(&mut self, spoof_command_high: u16, spoof_command_low: u16) {
+    pub fn update_steering(
+        &mut self,
+        spoof_command_high: u16,
+        spoof_command_low: u16,
+    ) -> Result<(), OxccError> {
         if self.control_state.enabled {
             // TODO - revisit this, enforce high->A, low->B
             self.steering_dac.output_ab(
                 ranges::coerce(SteeringSpoofHighSignal::clamp(spoof_command_high)),
                 ranges::coerce(SteeringSpoofLowSignal::clamp(spoof_command_low)),
-            );
+            )?;
         }
+
+        Ok(())
     }
 
     pub fn check_for_faults(
         &mut self,
         timer_ms: &MsTimer,
         debug_console: &mut DebugConsole,
-    ) -> Option<&OsccFaultReport> {
+    ) -> Result<Option<&OsccFaultReport>, OxccError> {
         if !self.control_state.enabled && !self.control_state.dtcs.are_any_set() {
             // Assumes this module already went through the proper transition into a faulted
             // and disabled state, and we do not want to double-report a possible duplicate
             // fault.
-            return None;
+            return Ok(None);
         }
 
         self.steering_torque.update();
@@ -161,7 +181,7 @@ impl SteeringModule {
 
         // sensor pins tied to ground - a value of zero indicates disconnection
         if inputs_grounded {
-            self.disable_control(debug_console);
+            self.disable_control(debug_console)?;
 
             self.control_state
                 .dtcs
@@ -171,11 +191,11 @@ impl SteeringModule {
 
             writeln!(debug_console, "Bad value read from torque sensor");
 
-            Some(&self.fault_report)
+            Ok(Some(&self.fault_report))
         } else if (self.filtered_diff > TORQUE_DIFFERENCE_OVERRIDE_THRESHOLD)
             && !self.control_state.operator_override
         {
-            self.disable_control(debug_console);
+            self.disable_control(debug_console)?;
 
             self.control_state
                 .dtcs
@@ -187,11 +207,11 @@ impl SteeringModule {
 
             writeln!(debug_console, "Steering operator override");
 
-            Some(&self.fault_report)
+            Ok(Some(&self.fault_report))
         } else {
             self.control_state.dtcs.clear_all();
             self.control_state.operator_override = false;
-            None
+            Ok(None)
         }
     }
 
@@ -210,41 +230,46 @@ impl SteeringModule {
         &self.steering_report
     }
 
-    // TODO - error handling
-    pub fn process_rx_frame(&mut self, can_frame: &CanFrame, debug_console: &mut DebugConsole) {
+    pub fn process_rx_frame(
+        &mut self,
+        can_frame: &CanFrame,
+        debug_console: &mut DebugConsole,
+    ) -> Result<(), OxccError> {
         if let CanFrame::DataFrame(ref frame) = can_frame {
             let id: u32 = frame.id().into();
             let data = frame.data();
 
             if (data[0] == OSCC_MAGIC_BYTE_0) && (data[1] == OSCC_MAGIC_BYTE_1) {
                 if id == OSCC_STEERING_ENABLE_CAN_ID.into() {
-                    self.enable_control(debug_console);
+                    self.enable_control(debug_console)?;
                 } else if id == OSCC_STEERING_DISABLE_CAN_ID.into() {
-                    self.disable_control(debug_console);
+                    self.disable_control(debug_console)?;
                 } else if id == OSCC_STEERING_COMMAND_CAN_ID.into() {
-                    self.process_steering_command(&OsccSteeringCommand::from(frame));
+                    self.process_steering_command(&OsccSteeringCommand::from(frame))?;
                 } else if id == OSCC_FAULT_REPORT_CAN_ID.into() {
-                    self.process_fault_report(&OsccFaultReport::from(frame), debug_console);
+                    self.process_fault_report(&OsccFaultReport::from(frame), debug_console)?;
                 }
             }
         }
+
+        Ok(())
     }
 
     fn process_fault_report(
         &mut self,
         fault_report: &OsccFaultReport,
         debug_console: &mut DebugConsole,
-    ) {
-        self.disable_control(debug_console);
-
+    ) -> Result<(), OxccError> {
         writeln!(
             debug_console,
             "Fault report received from: {} DTCs: {}",
             fault_report.fault_origin_id, fault_report.dtcs
         );
+
+        self.disable_control(debug_console)
     }
 
-    fn process_steering_command(&mut self, command: &OsccSteeringCommand) {
+    fn process_steering_command(&mut self, command: &OsccSteeringCommand) -> Result<(), OxccError> {
         let clamped_torque = num::clamp(
             command.torque_request * MAXIMUM_TORQUE_COMMAND,
             MINIMUM_TORQUE_COMMAND,
@@ -266,6 +291,6 @@ impl SteeringModule {
         let spoof_value_low = (STEPS_PER_VOLT * spoof_voltage_low) as u16;
         let spoof_value_high = (STEPS_PER_VOLT * spoof_voltage_high) as u16;
 
-        self.update_steering(spoof_value_high, spoof_value_low);
+        self.update_steering(spoof_value_high, spoof_value_low)
     }
 }

--- a/src/throttle_module.rs
+++ b/src/throttle_module.rs
@@ -13,6 +13,7 @@ use nucleo_f767zi::hal::can::CanFrame;
 use nucleo_f767zi::hal::prelude::*;
 use num;
 use oscc_magic_byte::*;
+use oxcc_error::OxccError;
 use ranges;
 use throttle_can_protocol::*;
 use types::*;
@@ -83,44 +84,63 @@ impl UnpreparedThrottleModule {
 }
 
 impl ThrottleModule {
-    fn disable_control(&mut self, debug_console: &mut DebugConsole) {
+    pub fn disable_control(&mut self, debug_console: &mut DebugConsole) -> Result<(), OxccError> {
+        let mut result = Ok(());
+
         if self.control_state.enabled {
             self.accelerator_position.prevent_signal_discontinuity();
 
-            self.throttle_dac.output_ab(
+            if let Err(_) = self.throttle_dac.output_ab(
                 DacOutput::clamp(self.accelerator_position.low()),
                 DacOutput::clamp(self.accelerator_position.high()),
-            );
+            ) {
+                result = Err(OxccError::IO);
+            }
 
+            // even if we've encountered an error, we can still disable
             self.throttle_pins.spoof_enable.set_low();
             self.control_state.enabled = false;
             writeln!(debug_console, "Throttle control disabled");
         }
+
+        result
     }
 
-    fn enable_control(&mut self, debug_console: &mut DebugConsole) {
+    fn enable_control(&mut self, debug_console: &mut DebugConsole) -> Result<(), OxccError> {
+        let mut result = Ok(());
+
         if !self.control_state.enabled && !self.control_state.operator_override {
             self.accelerator_position.prevent_signal_discontinuity();
 
-            self.throttle_dac.output_ab(
+            if let Err(_) = self.throttle_dac.output_ab(
                 DacOutput::clamp(self.accelerator_position.low()),
                 DacOutput::clamp(self.accelerator_position.high()),
-            );
-
-            self.throttle_pins.spoof_enable.set_high();
-            self.control_state.enabled = true;
-            writeln!(debug_console, "Throttle control enabled");
+            ) {
+                result = Err(OxccError::IO);
+            } else {
+                self.throttle_pins.spoof_enable.set_high();
+                self.control_state.enabled = true;
+                writeln!(debug_console, "Throttle control enabled");
+            }
         }
+
+        result
     }
 
-    fn update_throttle(&mut self, spoof_command_high: u16, spoof_command_low: u16) {
+    fn update_throttle(
+        &mut self,
+        spoof_command_high: u16,
+        spoof_command_low: u16,
+    ) -> Result<(), OxccError> {
         if self.control_state.enabled {
             // TODO - revisit this, enforce high->A, low->B
             self.throttle_dac.output_ab(
                 ranges::coerce(ThrottleSpoofHighSignal::clamp(spoof_command_high)),
                 ranges::coerce(ThrottleSpoofHighSignal::clamp(spoof_command_low)),
-            );
+            )?;
         }
+
+        Ok(())
     }
 
     /// Checks for any fresh (previously undetected or unhandled) faults
@@ -128,12 +148,12 @@ impl ThrottleModule {
         &mut self,
         timer_ms: &MsTimer,
         debug_console: &mut DebugConsole,
-    ) -> Option<&OsccFaultReport> {
+    ) -> Result<Option<&OsccFaultReport>, OxccError> {
         if !self.control_state.enabled && !self.control_state.dtcs.are_any_set() {
             // Assumes this module already went through the proper transition into a faulted
             // and disabled state, and we do not want to double-report a possible duplicate
             // fault.
-            return None;
+            return Ok(None);
         }
 
         self.accelerator_position.update();
@@ -154,7 +174,7 @@ impl ThrottleModule {
 
         // sensor pins tied to ground - a value of zero indicates disconnection
         if inputs_grounded {
-            self.disable_control(debug_console);
+            self.disable_control(debug_console)?;
 
             self.control_state
                 .dtcs
@@ -167,9 +187,9 @@ impl ThrottleModule {
                 "Bad value read from accelerator position sensor"
             );
 
-            Some(&self.fault_report)
+            Ok(Some(&self.fault_report))
         } else if operator_overridden && !self.control_state.operator_override {
-            self.disable_control(debug_console);
+            self.disable_control(debug_console)?;
 
             self.control_state
                 .dtcs
@@ -181,11 +201,11 @@ impl ThrottleModule {
 
             writeln!(debug_console, "Throttle operator override");
 
-            Some(&self.fault_report)
+            Ok(Some(&self.fault_report))
         } else {
             self.control_state.dtcs.clear_all();
             self.control_state.operator_override = false;
-            None
+            Ok(None)
         }
     }
 
@@ -200,41 +220,46 @@ impl ThrottleModule {
         &self.throttle_report
     }
 
-    // TODO - error handling
-    pub fn process_rx_frame(&mut self, can_frame: &CanFrame, debug_console: &mut DebugConsole) {
+    pub fn process_rx_frame(
+        &mut self,
+        can_frame: &CanFrame,
+        debug_console: &mut DebugConsole,
+    ) -> Result<(), OxccError> {
         if let CanFrame::DataFrame(ref frame) = can_frame {
             let id: u32 = frame.id().into();
             let data = frame.data();
 
             if (data[0] == OSCC_MAGIC_BYTE_0) && (data[1] == OSCC_MAGIC_BYTE_1) {
                 if id == OSCC_THROTTLE_ENABLE_CAN_ID.into() {
-                    self.enable_control(debug_console);
+                    self.enable_control(debug_console)?;
                 } else if id == OSCC_THROTTLE_DISABLE_CAN_ID.into() {
-                    self.disable_control(debug_console);
+                    self.disable_control(debug_console)?;
                 } else if id == OSCC_THROTTLE_COMMAND_CAN_ID.into() {
-                    self.process_throttle_command(&OsccThrottleCommand::from(frame));
+                    self.process_throttle_command(&OsccThrottleCommand::from(frame))?;
                 } else if id == OSCC_FAULT_REPORT_CAN_ID.into() {
-                    self.process_fault_report(&OsccFaultReport::from(frame), debug_console);
+                    self.process_fault_report(&OsccFaultReport::from(frame), debug_console)?;
                 }
             }
         }
+
+        Ok(())
     }
 
     fn process_fault_report(
         &mut self,
         fault_report: &OsccFaultReport,
         debug_console: &mut DebugConsole,
-    ) {
-        self.disable_control(debug_console);
-
+    ) -> Result<(), OxccError> {
         writeln!(
             debug_console,
             "Fault report received from: {} DTCs: {}",
             fault_report.fault_origin_id, fault_report.dtcs
         );
+
+        self.disable_control(debug_console)
     }
 
-    fn process_throttle_command(&mut self, command: &OsccThrottleCommand) {
+    fn process_throttle_command(&mut self, command: &OsccThrottleCommand) -> Result<(), OxccError> {
         let clamped_position = num::clamp(
             command.torque_request,
             MINIMUM_THROTTLE_COMMAND,
@@ -256,6 +281,6 @@ impl ThrottleModule {
         let spoof_value_low = (STEPS_PER_VOLT * spoof_voltage_low) as u16;
         let spoof_value_high = (STEPS_PER_VOLT * spoof_voltage_high) as u16;
 
-        self.update_throttle(spoof_value_high, spoof_value_low);
+        self.update_throttle(spoof_value_high, spoof_value_low)
     }
 }

--- a/src/vehicles/kial_niro.rs
+++ b/src/vehicles/kial_niro.rs
@@ -379,7 +379,6 @@ pub const THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MAX: u16 = 3446;
 
 pub type ThrottleSpoofHighSignal = ranges::Bounded<u16, U620, U3446>;
 
-
 /*
  * @brief Calculation to convert a throttle position to a low spoof voltage. */
 //

--- a/src/vehicles/kial_soul_ev.rs
+++ b/src/vehicles/kial_soul_ev.rs
@@ -147,7 +147,6 @@ pub const BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MAX: u16 = 1875;
 
 pub type BrakeSpoofHighSignal = ranges::Bounded<u16, U572, U1875>;
 
-
 /*
  * @brief Calculation to convert a brake position to a low spoof voltage. */
 //


### PR DESCRIPTION
- added various results to the functions that can provide them (only I/O related for now)
- stubbed out an error enum place holder to funnel the various types of HAL errors
- fix the DAC impl, updated HAL to be half-duplex by default (will split the peripheral later on)
- a low quality refactor of main that groups the various module related activities in an effort towards making error handling less awkward
- added an example error handler that ignores CAN Tx timeout errors