### PR TITLE
Move throttle spoof to PE2 so it can be on the Arduino headers

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -101,6 +101,7 @@ impl FullBoard {
         let mut gpioa = peripherals.GPIOA.split(&mut rcc.ahb1);
         let mut gpioc = peripherals.GPIOC.split(&mut rcc.ahb1);
         let mut gpiod = peripherals.GPIOD.split(&mut rcc.ahb1);
+        let mut gpioe = peripherals.GPIOE.split(&mut rcc.ahb1);
         let mut gpiof = peripherals.GPIOF.split(&mut rcc.ahb1);
 
         let brake_pins = BrakePins {
@@ -127,9 +128,9 @@ impl FullBoard {
             .into_push_pull_output(&mut gpioa.moder, &mut gpioa.otyper);
 
         let throttle_pins = ThrottlePins {
-            spoof_enable: gpiod
-                .pd10
-                .into_push_pull_output(&mut gpiod.moder, &mut gpiod.otyper),
+            spoof_enable: gpioe
+                .pe2
+                .into_push_pull_output(&mut gpioe.moder, &mut gpioe.otyper),
             accel_pos_sensor_high: gpioc
                 .pc3
                 .into_analog_input(&mut gpioc.moder, &mut gpioc.pupdr),

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,8 @@ use nucleo_f767zi::hal::can::Can;
 use nucleo_f767zi::hal::gpio::gpioa::{PA15, PA4, PA5, PA6, PA7};
 use nucleo_f767zi::hal::gpio::gpiob::{PB10, PB12, PB13, PB15, PB4};
 use nucleo_f767zi::hal::gpio::gpioc::{PC10, PC11, PC12, PC2};
-use nucleo_f767zi::hal::gpio::gpiod::{PD0, PD1, PD10, PD11, PD12, PD13};
+use nucleo_f767zi::hal::gpio::gpiod::{PD0, PD1, PD11, PD12, PD13};
+use nucleo_f767zi::hal::gpio::gpioe::PE2;
 use nucleo_f767zi::hal::gpio::{Output, PushPull, AF5, AF9};
 use nucleo_f767zi::hal::spi::Spi;
 use nucleo_f767zi::hal::stm32f7x7::{
@@ -41,7 +42,7 @@ pub type BrakeSpiNssPin = PA4<Output<PushPull>>;
 
 pub type BrakeDac = Mcp4922<BrakeSpi, BrakeSpiNssPin>;
 
-pub type ThrottleSpoofEnablePin = PD10<Output<PushPull>>;
+pub type ThrottleSpoofEnablePin = PE2<Output<PushPull>>;
 // AIN pins chosen to allow throttle module to own ADC2
 pub type AcceleratorPositionSensorHighPin = AnalogInput2Pin;
 pub type AcceleratorPositionSensorLowPin = AnalogInput6Pin;


### PR DESCRIPTION
Move throttle spoof enable pin from PD10 (connector CN12) to PE2 (connector CN10).

This lets all of the pins be on the Arduino compatible headers (CN7/CN8/CN9/CN10).