### PR TITLE
Migrate to an OSCC compatable ADC configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
  "cortex-m-semihosting 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "embedded-hal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxcc-nucleo-f767zi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxcc-nucleo-f767zi 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic-abort 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic-semihosting 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -135,13 +135,13 @@ dependencies = [
 
 [[package]]
 name = "oxcc-nucleo-f767zi"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "embedded-hal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "oxcc-stm32f767-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxcc-stm32f767-hal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "oxcc-stm32f767-hal"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -272,9 +272,9 @@ dependencies = [
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
 "checksum num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e96f040177bb3da242b5b1ecf3f54b5d5af3efbbfb18608977a5d2767b22f10"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
-"checksum oxcc-nucleo-f767zi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "68382ce6a2a4eb6e6a0f23fb121ee0b385c95145fc3c60c421629a9ec011a1b9"
+"checksum oxcc-nucleo-f767zi 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "df4fc98258001ad387aa7678c79b66133d0775c5b5a857c25c3faef47121baa8"
 "checksum oxcc-stm32f767 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a425a931fa001f275999e77eb96de9a60c0b39e6051255c0e7120bd28e1f0117"
-"checksum oxcc-stm32f767-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b011c1cf1332152ecf9bbaebf9d6b478bbaab64da1c0ec6d93c929e5a1a8f436"
+"checksum oxcc-stm32f767-hal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f941d9bcc6bf04cdf1e731ecc3b49477a96298b75852a6605dcc36a2c6589d4e"
 "checksum panic-abort 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c14a66511ed17b6a8b4256b868d7fd207836d891db15eea5195dbcaf87e630f"
 "checksum panic-semihosting 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1017854db1621a236488ac359b89b19a56dcb1cb45127376d04f23128cea7210"
 "checksum proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "ffe022fb8c8bd254524b0b3305906c1921fa37a84a644e29079a9e62200c3901"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ version = "0.6.3"
 features = ["device"]
 
 [dependencies.oxcc-nucleo-f767zi]
-version = "0.1.0"
+version = "0.1.1"
 features = ["rt"]
 
 [dependencies.num]

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ A port of [Open Source Car Control](https://github.com/jonlamb-gh/oscc) written 
 
 It is built around the traits and patterns provided by the [embedded-hal](https://github.com/rust-embedded/embedded-hal)
 project and community:
-see the [BSP crate](https://github.com/jonlamb-gh/nucleo-f767zi),
-the [HAL crate](https://github.com/jonlamb-gh/stm32f767-hal),
-and the [device crate](https://github.com/adamgreig/stm32-rs/tree/master/stm32f7).
+see the [BSP crate](https://github.com/jonlamb-gh/oxcc-nucleo-f767zi),
+the [HAL crate](https://github.com/jonlamb-gh/oxcc-stm32f767-hal),
+and the [device crate](https://github.com/jonlamb-gh/oxcc-stm32f767).
 
 ### OSCC Divergence
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ extern crate cortex_m_rt as rt;
 #[cfg(feature = "panic-over-semihosting")]
 extern crate cortex_m_semihosting;
 extern crate embedded_hal;
-extern crate oxcc_nucleo_f767zi as nucleo_f767zi;
 extern crate num;
+extern crate oxcc_nucleo_f767zi as nucleo_f767zi;
 #[cfg(feature = "panic-over-abort")]
 extern crate panic_abort;
 #[cfg(feature = "panic-over-semihosting")]

--- a/src/vehicles/kial_niro.rs
+++ b/src/vehicles/kial_niro.rs
@@ -101,9 +101,9 @@ pub const fn brake_position_to_volts_high(position: f32) -> f32 {
         + BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN
 }
 
-/// Value of the accelerator position that indicates operator
+/// Value of the brake position that indicates operator
 /// override. \[steps\]
-pub const BRAKE_PEDAL_OVERRIDE_THRESHOLD: u16 = 200 << 2;
+pub const BRAKE_PEDAL_OVERRIDE_THRESHOLD: u16 = 200;
 
 /// Minimum value of the high spoof signal that activates the brake
 /// lights. \[steps\]
@@ -243,4 +243,4 @@ pub const fn throttle_position_to_volts_high(position: f32) -> f32 {
 
 /// Value of the accelerator position that indicates operator
 /// override. \[steps\]
-pub const ACCELERATOR_OVERRIDE_THRESHOLD: u32 = 185 << 2;
+pub const ACCELERATOR_OVERRIDE_THRESHOLD: u32 = 185;

--- a/src/vehicles/kial_soul_ev.rs
+++ b/src/vehicles/kial_soul_ev.rs
@@ -105,9 +105,9 @@ pub const fn brake_position_to_volts_high(position: f32) -> f32 {
         + BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN
 }
 
-/// Value of the accelerator position that indicates operator
+/// Value of the brake position that indicates operator
 /// override. \[steps\]
-pub const BRAKE_PEDAL_OVERRIDE_THRESHOLD: u16 = 130 << 2;
+pub const BRAKE_PEDAL_OVERRIDE_THRESHOLD: u16 = 130;
 
 /// Minimum value of the low spoof signal that activates the brake
 /// lights. \[steps\]
@@ -246,4 +246,4 @@ pub const fn throttle_position_to_volts_high(position: f32) -> f32 {
 
 /// Value of the accelerator position that indicates operator
 /// override. \[steps\]
-pub const ACCELERATOR_OVERRIDE_THRESHOLD: u32 = 185 << 2;
+pub const ACCELERATOR_OVERRIDE_THRESHOLD: u32 = 185;

--- a/src/vehicles/kial_soul_petrol.rs
+++ b/src/vehicles/kial_soul_petrol.rs
@@ -269,6 +269,6 @@ pub const fn throttle_position_to_volts_high(position: f32) -> f32 {
         + THROTTLE_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN
 }
 
-/// Value of the accelerator position that indicates operator
+/// Value of the brake position that indicates operator
 /// override. \[steps\]
-pub const ACCELERATOR_OVERRIDE_THRESHOLD: u32 = 185 << 2;
+pub const ACCELERATOR_OVERRIDE_THRESHOLD: u32 = 185;


### PR DESCRIPTION
Prior to this commit, the ADCs were configured to run with
full 12 bit conversions. However this can be an inconvenience
for users who wish to use their existing vehicle configuration
data without re-calibrating.

This commit migrates the 12 bit ADC values back to the original
10 bit domain (vehicle constants) and uses the new HAL ADC
conversion resolution parameter for configurations.

Closes #12
Closes #32