### PR TITLE
Add default panic implementation with safety related disables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,6 @@ dependencies = [
  "embedded-hal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "oxcc-nucleo-f767zi 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "panic-abort 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic-semihosting 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -168,11 +167,6 @@ dependencies = [
  "oxcc-stm32f767 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "panic-abort"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "panic-semihosting"
@@ -275,7 +269,6 @@ dependencies = [
 "checksum oxcc-nucleo-f767zi 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "df4fc98258001ad387aa7678c79b66133d0775c5b5a857c25c3faef47121baa8"
 "checksum oxcc-stm32f767 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a425a931fa001f275999e77eb96de9a60c0b39e6051255c0e7120bd28e1f0117"
 "checksum oxcc-stm32f767-hal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f941d9bcc6bf04cdf1e731ecc3b49477a96298b75852a6605dcc36a2c6589d4e"
-"checksum panic-abort 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c14a66511ed17b6a8b4256b868d7fd207836d891db15eea5195dbcaf87e630f"
 "checksum panic-semihosting 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1017854db1621a236488ac359b89b19a56dcb1cb45127376d04f23128cea7210"
 "checksum proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "ffe022fb8c8bd254524b0b3305906c1921fa37a84a644e29079a9e62200c3901"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,6 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jonlamb-gh/oxcc"
 
-[dependencies.panic-abort]
-version = "0.3.1"
-optional = true
-
 [dependencies.panic-semihosting]
 version = "0.5.0"
 optional = true
@@ -53,11 +49,15 @@ codegen-units = 1 # better optimizations
 lto = true # better optimizations
 
 [features]
-default = ["kia-soul-ev", "panic-over-abort"]
+default = ["kia-soul-ev", "panic-abort"]
 kia-soul-ev = []
 kia-niro = []
 # No plans to support the Petrol, however it is stubbed out for use
 kia-soul-petrol = []
 # Panic stategies
+# Note that panic-over-semihosting requires a debugger to be attached
 panic-over-semihosting = ["cortex-m-semihosting", "panic-semihosting"]
-panic-over-abort = ["panic-abort"]
+# The default OxCC panic implementation will (attempt to) output
+# the PanicInfo to Serial3 of the board and disable all control
+# related functionality before aborting.
+panic-abort = []

--- a/src/board.rs
+++ b/src/board.rs
@@ -19,7 +19,7 @@ use nucleo_f767zi::hal::serial::Serial;
 use nucleo_f767zi::hal::spi::Spi;
 use nucleo_f767zi::hal::stm32f7x7;
 use nucleo_f767zi::hal::stm32f7x7::{ADC1, ADC2, ADC3, IWDG};
-use nucleo_f767zi::led::{Color, Leds};
+use nucleo_f767zi::led::Leds;
 use nucleo_f767zi::UserButtonPin;
 use vehicle::FAULT_HYSTERESIS;
 
@@ -511,25 +511,4 @@ impl HighLowReader for TorqueSensor {
     fn read_low(&self) -> u16 {
         self.adc3.read(AdcChannel::Adc3In8, ADC_SAMPLE_TIME)
     }
-}
-
-pub fn hard_fault_indicator() {
-    cortex_m::interrupt::free(|_cs| unsafe {
-        let peripherals = stm32f7x7::Peripherals::steal();
-        let mut rcc = peripherals.RCC.constrain();
-        let mut gpiob = peripherals.GPIOB.split(&mut rcc.ahb1);
-
-        let led_r = gpiob
-            .pb14
-            .into_push_pull_output(&mut gpiob.moder, &mut gpiob.otyper);
-        let led_g = gpiob
-            .pb0
-            .into_push_pull_output(&mut gpiob.moder, &mut gpiob.otyper);
-        let led_b = gpiob
-            .pb7
-            .into_push_pull_output(&mut gpiob.moder, &mut gpiob.otyper);
-
-        let mut leds = Leds::new(led_r, led_g, led_b);
-        leds[Color::Red].on();
-    });
 }

--- a/src/panic_abort.rs
+++ b/src/panic_abort.rs
@@ -1,0 +1,133 @@
+//! Panic behavior implementation for OxCC
+//!
+//! The implementation performs the following (in order):
+//! - disable safety/control related GPIO pins
+//! - enable red LED and brake lights as a fault indicator
+//! - output the PanicInfo to Serial3
+//! - `intrinsics::abort`
+//!
+//! **NOTE**
+//! The watchdog is enable by default, so you might not
+//! even notice the fault.
+//! It might be worth exposing the `hard_fault_indicator()`
+//! function so we can call it during initialization if
+//! the `ResetConditions` indicate a watchdog reset. That
+//! would persist the indication across panicing/faults.
+//! We could also disable the watchdog (and other interrupts)
+//! completely to stay in the abort.
+
+use core::panic::PanicInfo;
+use core::{intrinsics, ptr};
+use cortex_m::interrupt::CriticalSection;
+
+use nucleo_f767zi::hal::stm32f7x7;
+use nucleo_f767zi::hal::time::*;
+
+struct SerialOutputHandle;
+
+macro_rules! serial_print {
+    ($($arg:tt)*) => ({
+        use core::fmt::Write;
+        SerialOutputHandle.write_fmt(format_args!($($arg)*)).unwrap();
+    });
+}
+
+macro_rules! serial_println {
+    ($fmt:expr) => (serial_print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => (serial_print!(concat!($fmt, "\n"), $($arg)*));
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    cortex_m::interrupt::free(|cs| {
+        disable_controls_gpio(cs);
+        hard_fault_indicator(cs);
+        serial3_panicinfo_dump(cs, info);
+    });
+
+    unsafe { intrinsics::abort() }
+}
+
+/// Disable safety/control related GPIO
+fn disable_controls_gpio(_cs: &CriticalSection) {
+    let gpiod = unsafe { &*stm32f7x7::GPIOD::ptr() };
+    let gpioe = unsafe { &*stm32f7x7::GPIOE::ptr() };
+
+    // disable throttle controls spoof-enable pin on PE2
+    gpioe.moder.modify(|_, w| w.moder2().output());
+    gpioe.odr.modify(|_, w| w.odr2().clear_bit());
+
+    // disable steering controls spoof-enable pin on PD11
+    gpiod.moder.modify(|_, w| w.moder11().output());
+    gpiod.odr.modify(|_, w| w.odr11().clear_bit());
+
+    // disable brake controls spoof-enable pin on PD12
+    gpiod.moder.modify(|_, w| w.moder12().output());
+    gpiod.odr.modify(|_, w| w.odr12().clear_bit());
+}
+
+/// Enable the hard fault indication
+fn hard_fault_indicator(_cs: &CriticalSection) {
+    let gpiob = unsafe { &*stm32f7x7::GPIOB::ptr() };
+    let gpiod = unsafe { &*stm32f7x7::GPIOD::ptr() };
+
+    // turn red LED (PB14) on
+    gpiob.moder.modify(|_, w| w.moder14().output());
+    gpiob.odr.modify(|_, w| w.odr14().set_bit());
+
+    // enable the brake lights on PD13
+    gpiod.moder.modify(|_, w| w.moder13().output());
+    gpiod.odr.modify(|_, w| w.odr13().set_bit());
+}
+
+/// Output PanicInfo to Serial3
+fn serial3_panicinfo_dump(_cs: &CriticalSection, info: &PanicInfo) {
+    let rcc = unsafe { &*stm32f7x7::RCC::ptr() };
+    let usart = unsafe { &*stm32f7x7::USART3::ptr() };
+
+    // reset and enable
+    rcc.apb1enr.modify(|_, w| w.usart3en().enabled());
+    rcc.apb1rstr.modify(|_, w| w.uart3rst().set_bit());
+    rcc.apb1rstr.modify(|_, w| w.uart3rst().clear_bit());
+
+    let pclk1: Hertz = Hertz(216_000_000 / 4);
+    let baud_rate: Bps = 115_200.bps();
+    let brr = pclk1.0 / baud_rate.0;
+    usart.brr.write(|w| unsafe { w.bits(brr) });
+
+    // enable USART, tx, rx
+    usart.cr1.write(|w| w.ue().set_bit().te().set_bit());
+
+    serial_println!("\n!!! WARNING !!!\n{}", info);
+}
+
+fn putchar(byte: u8) -> Result<(), ()> {
+    let isr = unsafe { (*stm32f7x7::USART3::ptr()).isr.read() };
+
+    if isr.txe().bit_is_set() && isr.tc().bit_is_set() {
+        unsafe { ptr::write_volatile(&(*stm32f7x7::USART3::ptr()).tdr as *const _ as *mut _, byte) }
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
+fn flush() -> Result<(), ()> {
+    let isr = unsafe { (*stm32f7x7::USART3::ptr()).isr.read() };
+
+    if isr.tc().bit_is_set() {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
+impl ::core::fmt::Write for SerialOutputHandle {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        for &b in s.as_bytes() {
+            while putchar(b).is_err() {}
+            while flush().is_err() {}
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add a default panic implementation that performs the following (in order):

- disable safety/control related GPIO pins
- enable red LED and brake lights as a fault indicator
- output the PanicInfo to Serial3
- call `intrinsics::abort`

**NOTE**
The watchdog is enabled by default, so you might not even notice the fault indications.
It might be worth exposing the `hard_fault_indicator()` function so we
can call it during initialization if the `ResetConditions` indicate
a watchdog reset. That would persist the indication across panicing/faults.
We could also disable the watchdog (and other interrupts) completely to stay
in a loop.